### PR TITLE
Migrate database to app group location

### DIFF
--- a/macadamia.xcodeproj/project.pbxproj
+++ b/macadamia.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		377FFF012BC451AB00DD2635 /* release-notes.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "release-notes.md"; sourceTree = "<group>"; };
 		378B20472D09F3FD003FEEBD /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
 		3793B99D2CFCC8F80077F755 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
+		379A27EE2E3029A800827CC1 /* macadamia.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = macadamia.entitlements; sourceTree = "<group>"; };
 		379ED0402D4580A900D432D0 /* TOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TOS.swift; sourceTree = "<group>"; };
 		37DC18A12B8669A900F9B37B /* macadamiaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = macadamiaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		37DC18A32B8669A900F9B37B /* macadamiaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = macadamiaTests.swift; sourceTree = "<group>"; };
@@ -116,6 +117,7 @@
 		372034B82B29E1BC00C4F955 /* macadamia */ = {
 			isa = PBXGroup;
 			children = (
+				379A27EE2E3029A800827CC1 /* macadamia.entitlements */,
 				37E700122B4C0DD100CB1A58 /* Launch Screen.storyboard */,
 				372034B92B29E1BC00C4F955 /* macadamiaApp.swift */,
 				378B20472D09F3FD003FEEBD /* Error.swift */,
@@ -438,6 +440,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
+				CODE_SIGN_ENTITLEMENTS = macadamia/macadamia.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"macadamia/Preview Content\"";
@@ -477,6 +480,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
+				CODE_SIGN_ENTITLEMENTS = macadamia/macadamia.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"macadamia/Preview Content\"";

--- a/macadamia/PersistentModelV1/PersistentModelV1.swift
+++ b/macadamia/PersistentModelV1/PersistentModelV1.swift
@@ -85,13 +85,15 @@ class DatabaseManager {
         do {
             logger.info("Starting database migration from: \(defaultStoreURL.path)")
             
-            // SwiftData will create its own database structure in the app group
-            // We'll copy the store files to where SwiftData expects them
-            let targetStoreURL = appGroupURL.appendingPathComponent("default.store")
+            // SwiftData expects the database in Library/Application Support within the app group
+            let libraryURL = appGroupURL.appendingPathComponent("Library")
+            let appSupportURL = libraryURL.appendingPathComponent("Application Support")
+            let targetStoreURL = appSupportURL.appendingPathComponent("default.store")
             
-            // Create app group directory if needed
-            if !fileManager.fileExists(atPath: appGroupURL.path) {
-                try fileManager.createDirectory(at: appGroupURL, withIntermediateDirectories: true)
+            // Create the directory structure if needed
+            if !fileManager.fileExists(atPath: appSupportURL.path) {
+                try fileManager.createDirectory(at: appSupportURL, withIntermediateDirectories: true)
+                logger.info("Created Application Support directory in app group")
             }
             
             // Copy the main store file
@@ -99,7 +101,7 @@ class DatabaseManager {
                 try fileManager.removeItem(at: targetStoreURL)
             }
             try fileManager.copyItem(at: defaultStoreURL, to: targetStoreURL)
-            logger.info("Copied database file to app group")
+            logger.info("Copied database file to app group Application Support")
             
             // Copy associated files (.store-shm, .store-wal)
             let storeDir = defaultStoreURL.deletingLastPathComponent()
@@ -108,7 +110,7 @@ class DatabaseManager {
             for suffix in ["-shm", "-wal"] {
                 let sourceFile = storeDir.appendingPathComponent("\(storeName).store\(suffix)")
                 if fileManager.fileExists(atPath: sourceFile.path) {
-                    let targetFile = appGroupURL.appendingPathComponent("\(storeName).store\(suffix)")
+                    let targetFile = appSupportURL.appendingPathComponent("\(storeName).store\(suffix)")
                     try? fileManager.copyItem(at: sourceFile, to: targetFile)
                     logger.info("Copied \(suffix) file")
                 }

--- a/macadamia/PersistentModelV1/PersistentModelV1.swift
+++ b/macadamia/PersistentModelV1/PersistentModelV1.swift
@@ -32,6 +32,18 @@ class DatabaseManager {
         if let appGroupURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: DatabaseManager.appGroupID) {
             logger.info("App group container found at: \(appGroupURL.path)")
             
+            // Ensure Library/Application Support directory exists to avoid CoreData verbose errors
+            let libraryURL = appGroupURL.appendingPathComponent("Library")
+            let appSupportURL = libraryURL.appendingPathComponent("Application Support")
+            if !FileManager.default.fileExists(atPath: appSupportURL.path) {
+                do {
+                    try FileManager.default.createDirectory(at: appSupportURL, withIntermediateDirectories: true)
+                    logger.info("Created Application Support directory in app group")
+                } catch {
+                    logger.error("Failed to create Application Support directory: \(error)")
+                }
+            }
+            
             // Check if we need to migrate
             DatabaseManager.performMigrationIfNeeded(to: appGroupURL, appGroupID: DatabaseManager.appGroupID)
             

--- a/macadamia/Wallet/WalletView.swift
+++ b/macadamia/Wallet/WalletView.swift
@@ -71,7 +71,7 @@ struct WalletView: View {
                 Spacer().frame(maxHeight: 20)
                 MinimalEventList()
                 Spacer().frame(maxHeight: 20)
-                HStack(alignment: .bottom) {
+                HStack(alignment: .center) {
                     // MARK: BUTTON "RECEIVE" -
                     Templates.Menu(
                         configuration: {

--- a/macadamia/macadamia.entitlements
+++ b/macadamia/macadamia.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.cypherbase.macadamia</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Migrating the database to an app group location allows extensions to the wallet like a Messages sidecar app in the future.