### PR TITLE
Add more fiat units and input conversion

### DIFF
--- a/macadamia/Misc/Currency.swift
+++ b/macadamia/Misc/Currency.swift
@@ -7,6 +7,83 @@
 
 import Foundation
 
+enum ConversionUnit: String, Codable, CaseIterable {
+    case usd = "USD"
+    case eur = "EUR"
+    case jpy = "JPY"
+    case gbp = "GBP"
+    case aud = "AUD"
+    case cad = "CAD"
+    case chf = "CHF"
+    case cny = "CNY"
+    case hkd = "HKD"
+    case nzd = "NZD"
+    case sek = "SEK"
+    case krw = "KRW"
+    case sgd = "SGD"
+    case nok = "NOK"
+    case mxn = "MXN"
+    
+    var displayName: String {
+        switch self {
+        case .usd: return "US Dollar"
+        case .eur: return "Euro"
+        case .jpy: return "Japanese Yen"
+        case .gbp: return "British Pound"
+        case .aud: return "Australian Dollar"
+        case .cad: return "Canadian Dollar"
+        case .chf: return "Swiss Franc"
+        case .cny: return "Chinese Yuan"
+        case .hkd: return "Hong Kong Dollar"
+        case .nzd: return "New Zealand Dollar"
+        case .sek: return "Swedish Krona"
+        case .krw: return "South Korean Won"
+        case .sgd: return "Singapore Dollar"
+        case .nok: return "Norwegian Krone"
+        case .mxn: return "Mexican Peso"
+        }
+    }
+    
+    var symbol: String {
+        switch self {
+        case .usd: return "$"
+        case .eur: return "€"
+        case .jpy: return "¥"
+        case .gbp: return "£"
+        case .aud: return "A$"
+        case .cad: return "C$"
+        case .chf: return "CHF"
+        case .cny: return "¥"
+        case .hkd: return "HK$"
+        case .nzd: return "NZ$"
+        case .sek: return "kr"
+        case .krw: return "₩"
+        case .sgd: return "S$"
+        case .nok: return "kr"
+        case .mxn: return "$"
+        }
+    }
+    
+    init?(_ string: String?) {
+        if let match = ConversionUnit.allCases.first(where: { $0.rawValue.lowercased() == string?.lowercased() }) {
+            self = match
+        } else {
+            return nil
+        }
+    }
+}
+
+func amountDisplayString(_ amount: Int, unit: ConversionUnit, negative: Bool = false) -> String {
+    let numberFormatter = NumberFormatter()
+    
+    let prefix = (negative && amount != 0) ? "- " : ""
+    
+    numberFormatter.numberStyle = .currency
+    numberFormatter.currencyCode = unit.rawValue // ConversionUnit uses ISO currency codes
+    let fiat = Double(amount) / 100.0
+    return prefix + (numberFormatter.string(from: NSNumber(value: fiat)) ?? "")
+}
+
 func amountDisplayString(_ amount: Int, unit: AppSchemaV1.Unit, negative: Bool = false) -> String {
     let numberFormatter = NumberFormatter()
     

--- a/macadamia/Misc/Currency.swift
+++ b/macadamia/Misc/Currency.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 enum ConversionUnit: String, Codable, CaseIterable {
+    case none = "NONE"
     case usd = "USD"
     case eur = "EUR"
     case jpy = "JPY"
@@ -26,6 +27,7 @@ enum ConversionUnit: String, Codable, CaseIterable {
     
     var displayName: String {
         switch self {
+        case .none: return "None"
         case .usd: return "US Dollar"
         case .eur: return "Euro"
         case .jpy: return "Japanese Yen"
@@ -46,6 +48,7 @@ enum ConversionUnit: String, Codable, CaseIterable {
     
     var symbol: String {
         switch self {
+        case .none: return ""
         case .usd: return "$"
         case .eur: return "€"
         case .jpy: return "¥"
@@ -85,6 +88,8 @@ enum ConversionUnit: String, Codable, CaseIterable {
 }
 
 func amountDisplayString(_ amount: Int, unit: ConversionUnit, negative: Bool = false) -> String {
+    guard unit != .none else { return "" }
+    
     let numberFormatter = NumberFormatter()
     
     let prefix = (negative && amount != 0) ? "- " : ""

--- a/macadamia/Misc/Currency.swift
+++ b/macadamia/Misc/Currency.swift
@@ -71,6 +71,17 @@ enum ConversionUnit: String, Codable, CaseIterable {
             return nil
         }
     }
+    
+    /// Access the preferred conversion unit directly from UserDefaults without initializing AppState
+    static var preferred: ConversionUnit {
+        let key = "PreferredCurrencyConversionUnit"
+        if let unitString = UserDefaults.standard.string(forKey: key),
+           let unit = ConversionUnit(unitString) {
+            return unit
+        } else {
+            return .usd // Default fallback
+        }
+    }
 }
 
 func amountDisplayString(_ amount: Int, unit: ConversionUnit, negative: Bool = false) -> String {

--- a/macadamia/Misc/NumericalInputView.swift
+++ b/macadamia/Misc/NumericalInputView.swift
@@ -1,0 +1,243 @@
+//
+//  NumericalInputView.swift
+//  macadamia
+//
+//  Created by zm on 08.09.25.
+//
+
+import SwiftUI
+import Foundation
+import UIKit
+
+struct NumericalInputView: View {
+    
+    @Binding var output: Int
+    let baseUnit: AppSchemaV1.Unit
+    
+    // Optional exchange rates - if nil, conversion features are disabled
+    let exchangeRates: AppState.ExchangeRate?
+    
+    @State private var input: String = ""
+    @State private var inputIsFiat = false
+    @FocusState private var isInputFocused: Bool
+    
+    private var conversionUnit: ConversionUnit {
+        ConversionUnit.preferred
+    }
+    
+    private var placeholder: String {
+        return "Enter amount"
+    }
+    
+    private var keyboardType: UIKeyboardType {
+        .decimalPad // Always use decimal pad, validation will filter decimals in sats mode
+    }
+    
+    private var inputUnit: String {
+        if inputIsFiat {
+            return conversionUnit.rawValue
+        } else {
+            return "sats"
+        }
+    }
+    
+    private var toggleButtonDisabled: Bool {
+        exchangeRates == nil
+    }
+    
+    private var conversionText: String {
+        if inputIsFiat {
+            // Input is fiat, show sats conversion
+            if input.isEmpty {
+                return "0 sats"
+            } else if let sats = convertFiatToSats() {
+                return "\(sats.formatted(.number)) sats"
+            } else {
+                return "Conversion unavailable"
+            }
+        } else {
+            // Input is sats, show fiat conversion
+            if input.isEmpty {
+                if exchangeRates != nil {
+                    return amountDisplayString(0, unit: conversionUnit)
+                } else {
+                    return "Conversion unavailable"
+                }
+            } else if let sats = Int(input), let fiatAmount = convertSatsToFiat(sats) {
+                return amountDisplayString(fiatAmount, unit: conversionUnit)
+            } else {
+                return "Conversion unavailable"
+            }
+        }
+    }
+    
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    TextField(placeholder, text: $input)
+                        .keyboardType(keyboardType)
+                        .focused($isInputFocused)
+                        .font(.title3)
+                            .onChange(of: input) { _, newValue in
+                                input = validateInput(newValue)
+                                updateOutput()
+                            }
+                    
+                    Text(inputUnit)
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                        .monospaced()
+                    
+                }
+                
+                Text(conversionText)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .animation(.default, value: conversionText)
+            }
+            Spacer(minLength: 30)
+            Button {
+                toggleInputMode()
+            } label: {
+                Image(systemName: "arrow.trianglehead.2.clockwise")
+                    .foregroundColor(toggleButtonDisabled ? .gray : .accentColor)
+            }
+            .disabled(toggleButtonDisabled)
+        }
+        .onAppear {
+            updateOutput()
+        }
+    }
+    
+    private func convertFiatToSats() -> Int? {
+        guard let rates = exchangeRates,
+              let bitcoinPrice = rates.rate(for: conversionUnit) else {
+            return nil
+        }
+        
+        // Normalize decimal separator (replace comma with period for Double conversion)
+        let normalizedInput = input.replacingOccurrences(of: ",", with: ".")
+        
+        guard let fiatValue = Double(normalizedInput) else {
+            return nil
+        }
+        
+        let bitcoinAmount = fiatValue / bitcoinPrice
+        return Int(round(bitcoinAmount * 100_000_000.0))
+    }
+    
+    private func convertSatsToFiat(_ sats: Int) -> Int? {
+        guard let rates = exchangeRates,
+              let bitcoinPrice = rates.rate(for: conversionUnit) else {
+            return nil
+        }
+        
+        let bitcoinAmount = Double(sats) / 100_000_000.0
+        let fiatValue = bitcoinAmount * bitcoinPrice
+        return Int(round(fiatValue * 100.0)) // Convert to cents
+    }
+    
+    private func validateInput(_ value: String) -> String {
+        if inputIsFiat {
+            // Fiat mode: allow digits and up to 2 decimal places (support both . and , as decimal separators)
+            
+            // Remove any non-numeric characters except decimal separators
+            let filtered = value.filter { $0.isNumber || $0 == "." || $0 == "," }
+            
+            // Count total decimal separators (both . and ,)
+            let decimalCount = filtered.filter { $0 == "." || $0 == "," }.count
+            
+            // Only allow one decimal separator
+            if decimalCount > 1 {
+                return input // Return previous valid input
+            }
+            
+            // Find the decimal separator (. or ,) and split on it
+            var components: [String] = []
+            if filtered.contains(".") {
+                components = filtered.components(separatedBy: ".")
+            } else if filtered.contains(",") {
+                components = filtered.components(separatedBy: ",")
+            } else {
+                components = [filtered]
+            }
+            
+            // Limit to 2 decimal places
+            if components.count == 2 && components[1].count > 2 {
+                let separator = filtered.contains(".") ? "." : ","
+                return String(components[0] + separator + String(components[1].prefix(2)))
+            }
+            
+            return filtered
+        } else {
+            // Sats mode: only allow digits (integers only)
+            return value.filter { $0.isNumber }
+        }
+    }
+    
+    private func updateOutput() {
+        if inputIsFiat {
+            output = convertFiatToSats() ?? 0
+        } else {
+            output = Int(input) ?? 0
+        }
+    }
+    
+    private func toggleInputMode() {
+        guard !toggleButtonDisabled else { return }
+        
+        withAnimation(.easeInOut(duration: 0.2)) {
+            if inputIsFiat {
+                // Convert current fiat input to sats
+                if let sats = convertFiatToSats() {
+                    input = String(sats)
+                }
+            } else {
+                // Convert current sats input to fiat
+                if let sats = Int(input), let fiatCents = convertSatsToFiat(sats) {
+                    let fiatValue = Double(fiatCents) / 100.0
+                    // Use the locale's preferred decimal separator, but default to period
+                    let decimalSeparator = NumberFormatter().decimalSeparator ?? "."
+                    input = String(format: "%.2f", fiatValue).replacingOccurrences(of: ".", with: decimalSeparator)
+                }
+            }
+            
+            inputIsFiat.toggle()
+        }
+    }
+}
+
+// Convenience initializer for use with AppState
+extension NumericalInputView {
+    init(output: Binding<Int>, baseUnit: AppSchemaV1.Unit, appState: AppState) {
+        self._output = output
+        self.baseUnit = baseUnit
+        self.exchangeRates = appState.exchangeRates
+    }
+}
+
+#Preview {
+    struct PreviewWrapper: View {
+        @State private var amount = 100000
+        
+        var body: some View {
+            VStack {
+                Text("Amount: \(amount) sats")
+                    .font(.headline)
+                    .padding()
+                
+                NumericalInputView(
+                    output: $amount,
+                    baseUnit: .sat,
+                    exchangeRates: nil
+                )
+                .padding()
+                
+                Spacer()
+            }
+        }
+    }
+    
+    return PreviewWrapper()
+}

--- a/macadamia/Misc/NumericalInputView.swift
+++ b/macadamia/Misc/NumericalInputView.swift
@@ -42,10 +42,12 @@ struct NumericalInputView: View {
     }
     
     private var toggleButtonDisabled: Bool {
-        exchangeRates == nil
+        exchangeRates == nil || conversionUnit == .none
     }
     
     private var conversionText: String {
+        guard conversionUnit != .none else { return "" }
+        
         if inputIsFiat {
             // Input is fiat, show sats conversion
             if input.isEmpty {
@@ -91,19 +93,23 @@ struct NumericalInputView: View {
                     
                 }
                 
-                Text(conversionText)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .animation(.default, value: conversionText)
+                if conversionUnit != .none {
+                    Text(conversionText)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .animation(.default, value: conversionText)
+                }
             }
-            Spacer(minLength: 30)
-            Button {
-                toggleInputMode()
-            } label: {
-                Image(systemName: "arrow.trianglehead.2.clockwise")
-                    .foregroundColor(toggleButtonDisabled ? .gray : .accentColor)
+            if conversionUnit != .none {
+                Spacer(minLength: 30)
+                Button {
+                    toggleInputMode()
+                } label: {
+                    Image(systemName: "arrow.trianglehead.2.clockwise")
+                        .foregroundColor(toggleButtonDisabled ? .gray : .accentColor)
+                }
+                .disabled(toggleButtonDisabled)
             }
-            .disabled(toggleButtonDisabled)
         }
         .onAppear {
             updateOutput()

--- a/macadamia/Settings/SettingsView.swift
+++ b/macadamia/Settings/SettingsView.swift
@@ -112,7 +112,7 @@ struct ConversionPicker: View {
     }
     
     var body: some View {
-        Picker("Display Fiat Value as:", selection: $selectedUnit) {
+        Picker("Show Fiat: ", selection: $selectedUnit) {
             ForEach(conversionUnits, id: \.self) { unit in
                 Text(unit.displayName).tag(unit)
             }

--- a/macadamia/Settings/SettingsView.swift
+++ b/macadamia/Settings/SettingsView.swift
@@ -103,31 +103,25 @@ struct SettingsView: View {
 struct ConversionPicker: View {
     @EnvironmentObject private var appState: AppState
     
-    let units = ["USD", "EUR", "none"]
+    let conversionUnits = ConversionUnit.allCases
     
-    @State private var selectedUnitString:String
+    @State private var selectedUnit: ConversionUnit
     
     init() {
-        _selectedUnitString = State(initialValue: "none")
+        _selectedUnit = State(initialValue: .usd)
     }
     
     var body: some View {
-        Picker("Display Fiat Value as:", selection: $selectedUnitString) {
-            ForEach(units, id: \.self) { unitString in
-                Text(unitString)
+        Picker("Display Fiat Value as:", selection: $selectedUnit) {
+            ForEach(conversionUnits, id: \.self) { unit in
+                Text(unit.displayName).tag(unit)
             }
         }
         .onAppear(perform: {
-            if let initial = units.first(where: { $0.lowercased() == appState.preferredConversionUnit.rawValue }) {
-                selectedUnitString = initial
-            } else {
-                logger.warning("Conversion picker could not set initial value from user defaults. this will get wonky")
-            }
+            selectedUnit = appState.preferredConversionUnit
         })
-        .onChange(of: selectedUnitString) { oldValue, newValue in
-            if let unit = Unit(newValue) {
-                appState.preferredConversionUnit = unit
-            }
+        .onChange(of: selectedUnit) { oldValue, newValue in
+            appState.preferredConversionUnit = newValue
         }
     }
 }

--- a/macadamia/Wallet/BalanceCard.swift
+++ b/macadamia/Wallet/BalanceCard.swift
@@ -53,17 +53,12 @@ struct BalanceCard: View {
                             .foregroundColor(Color.gray)
                     }
                     Spacer()
-                    switch appState.preferredConversionUnit {
-                    case .usd, .eur:
-                        HStack {
-                            Text(convertedBalance)
-                            Spacer()
-                        }
-                        .opacity(0.7)
-                        .animation(.default, value: convertedBalance)
-                    default:
-                        EmptyView()
+                    HStack {
+                        Text(convertedBalance)
+                        Spacer()
                     }
+                    .opacity(0.7)
+                    .animation(.default, value: convertedBalance)
                 }
                 .padding(24)
                 .frame(width: cardWidth, height: cardHeight)
@@ -99,15 +94,13 @@ struct BalanceCard: View {
             return
         }
                 
-        let bitcoinPrice:Int
-        switch appState.preferredConversionUnit {
-        case .usd: bitcoinPrice = prices.usd
-        case .eur: bitcoinPrice = prices.eur
-        default: convertedBalance = "?"; return
+        guard let bitcoinPrice = prices.rate(for: appState.preferredConversionUnit) else {
+            convertedBalance = "?"
+            return
         }
                 
         let bitcoinAmount = Double(balance) / 100_000_000.0
-        let fiatValue = bitcoinAmount * Double(bitcoinPrice)
+        let fiatValue = bitcoinAmount * bitcoinPrice
         var cents = Int(round(fiatValue * 100.0))
         
         var prefix = ""

--- a/macadamia/Wallet/BalanceCard.swift
+++ b/macadamia/Wallet/BalanceCard.swift
@@ -53,12 +53,14 @@ struct BalanceCard: View {
                             .foregroundColor(Color.gray)
                     }
                     Spacer()
-                    HStack {
-                        Text(convertedBalance)
-                        Spacer()
+                    if appState.preferredConversionUnit != .none {
+                        HStack {
+                            Text(convertedBalance)
+                            Spacer()
+                        }
+                        .opacity(0.7)
+                        .animation(.default, value: convertedBalance)
                     }
-                    .opacity(0.7)
-                    .animation(.default, value: convertedBalance)
                 }
                 .padding(24)
                 .frame(width: cardWidth, height: cardHeight)
@@ -87,6 +89,10 @@ struct BalanceCard: View {
     
     @MainActor
     private func convert() {
+        guard appState.preferredConversionUnit != .none else {
+            convertedBalance = ""
+            return
+        }
         
         convertedBalance = "..."
 


### PR DESCRIPTION
This PR add more fiat units for conversion and the ability to input an amount in fiat to be converted to bitcoin if the operation is on a "sat" keyset.

Fixes #31 