### PR TITLE
fix hardcoded absolute path for macadamiaMessages entitlements

### DIFF
--- a/macadamia.xcodeproj/project.pbxproj
+++ b/macadamia.xcodeproj/project.pbxproj
@@ -688,7 +688,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
-				CODE_SIGN_ENTITLEMENTS = /Users/dariolass/Developer/macadamia/macadamia/macadamiaMessages/macadamiaMessages.entitlements;
+				CODE_SIGN_ENTITLEMENTS = macadamia/macadamiaMessages/macadamiaMessages.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -720,7 +720,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = "iMessage App Icon";
-				CODE_SIGN_ENTITLEMENTS = /Users/dariolass/Developer/macadamia/macadamia/macadamiaMessages/macadamiaMessages.entitlements;
+				CODE_SIGN_ENTITLEMENTS = macadamia/macadamiaMessages/macadamiaMessages.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;


### PR DESCRIPTION
The CODE_SIGN_ENTITLEMENTS for the macadamiaMessages extension target used an absolute path (/Users/dariolass/Developer/...) which breaks builds on other machines. Changed to a project-relative path.

----
- [X] I made sure to choose branch RELEASE as the target for this pull request 
