### PR TITLE
tolerate inactive keysets with invalid IDs in addMint

### DIFF
--- a/macadamia/PersistentModelV1/PersistentModelV1.swift
+++ b/macadamia/PersistentModelV1/PersistentModelV1.swift
@@ -568,8 +568,23 @@ enum AppSchemaV1: VersionedSchema {
         
         let mints = activeWallet.mints
         
-        guard mint.keysets.allSatisfy(\.validID) else {
-            throw macadamiaError.mintVerificationError("This mint is using invalid keyset IDs, you should not trust it.")
+        // Validate keyset IDs, requiring at least all active keysets to be valid.
+        // Inactive keysets with invalid IDs are logged but tolerated,
+        // since mints may stop properly serving keys for rotated keysets.
+        let activeKeysets = mint.keysets.filter(\.active)
+        let inactiveKeysets = mint.keysets.filter { !$0.active }
+
+        let invalidActive = activeKeysets.filter { !$0.validID }
+        let invalidInactive = inactiveKeysets.filter { !$0.validID }
+
+        if !invalidInactive.isEmpty {
+            databaseLogger.warning("Mint \(mint.url.absoluteString) has \(invalidInactive.count) inactive keyset(s) with invalid IDs: \(invalidInactive.map(\.keysetID).joined(separator: ", "))")
+        }
+
+        guard invalidActive.isEmpty else {
+            let failedIDs = invalidActive.map(\.keysetID).joined(separator: ", ")
+            databaseLogger.error("Mint \(mint.url.absoluteString) has active keyset(s) with invalid IDs: \(failedIDs)")
+            throw macadamiaError.mintVerificationError("This mint has active keyset(s) with invalid IDs (\(failedIDs)). You should not trust it.")
         }
         
         if let colliding = mints.filter({ $0.hidden == false }).keysetCollisions(with: mint) {


### PR DESCRIPTION
## Summary
- The `mint.keysets.allSatisfy(\.validID)` check in `addMint` rejects the entire mint if any single keyset (including inactive ones) fails validation
- Changed to only strictly validate active keysets; inactive keysets with invalid IDs are logged as warnings but tolerated
- Error messages now include the failing keyset ID(s) for easier debugging

## Context
On mints that have rotated from v0 to v2 keysets, the inactive v0 keyset's keys may no longer be properly served. This causes `validID` to fail for the inactive keyset, which blocks the entire mint from being added — even though the active v2 keyset is perfectly valid.

## Test plan
- [ ] Verify successful connection to a mint with inactive v0 + active v2 keysets
- [ ] Verify that a mint with an invalid active keyset is still rejected
- [ ] Build confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)