### PR TITLE
Add fiat-denominated send amounts to the iMessage app

### DIFF
--- a/macadamia.xcodeproj/project.pbxproj
+++ b/macadamia.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 				AmountView.swift,
 				Currency.swift,
 				MintPicker.swift,
+				NumericalInputView.swift,
 				TokenText.swift,
 			);
 			target = 37C4CC2D2E5CA4660028E4FE /* macadamiaMessages */;

--- a/macadamia/AppState.swift
+++ b/macadamia/AppState.swift
@@ -18,13 +18,8 @@ class AppState: ObservableObject {
     
     @Published var pendingDeepLink: DeepLink?
     
-    private static let conversionUnitKey = "PreferredCurrencyConversionUnit"
     private static let lastRNackHashKey = "LastReleaseNotesAcknoledgedHash"
     private static let firstLaunchFlag = "HasLaunchedBefore"
-    
-    struct ExchangeRateResponse: Decodable {
-        let bitcoin: ExchangeRate
-    }
     
     static func showReleaseNotes() -> Bool {
         let releaseNotesSeenHash = UserDefaults.standard.string(forKey: AppState.lastRNackHashKey)
@@ -38,27 +33,9 @@ class AppState: ObservableObject {
         }
     }
     
-    struct ExchangeRate: Decodable, Equatable {
-        let rates: [String: Double]
-        
-        init(from decoder: Decoder) throws {
-            let container = try decoder.singleValueContainer()
-            rates = try container.decode([String: Double].self)
-        }
-        
-        // Regular initializer for mocking/testing
-        init(rates: [String: Double]) {
-            self.rates = rates
-        }
-        
-        func rate(for unit: Currency.Unit) -> Double? {
-            return rates[unit.currencyCode.lowercased()]
-        }
-    }
-    
     @Published var preferredConversionUnit: Currency.Unit {
         didSet {
-            UserDefaults.standard.setValue(preferredConversionUnit.currencyCode, forKey: AppState.conversionUnitKey)
+            Currency.Unit.savePreferred(preferredConversionUnit)
         }
     }
 
@@ -70,13 +47,14 @@ class AppState: ObservableObject {
     }
 
     init() {
-        let candidate: Currency.Unit? = UserDefaults.standard
-            .string(forKey: AppState.conversionUnitKey)
-            .map { Currency.Unit(code: $0) }
-        if let candidate, candidate.kind == .fiat || candidate.kind == .none {
+        Currency.Unit.migratePreferredFromStandardDefaultsIfNeeded()
+
+        let candidate = Currency.Unit.preferred
+        if candidate.kind == .fiat || candidate.kind == .none {
             preferredConversionUnit = candidate
         } else {
             preferredConversionUnit = .usd
+            Currency.Unit.savePreferred(.usd)
         }
 
         concealAmounts = AmountConcealment.userDefaults.bool(forKey: AmountConcealment.userDefaultsKey)
@@ -91,7 +69,7 @@ class AppState: ObservableObject {
         
         // Provide mock exchange rates for previews
         if preferredUnit != .none {
-            self.exchangeRates = ExchangeRate(rates: [
+            self.exchangeRates = Currency.ExchangeRate(rates: [
                 "usd": 95000.0,
                 "eur": 87000.0,
                 "gbp": 75000.0,
@@ -104,7 +82,7 @@ class AppState: ObservableObject {
         // Don't call loadExchangeRates() for previews
     }
     
-    @Published var exchangeRates: ExchangeRate?
+    @Published var exchangeRates: Currency.ExchangeRate?
 
     func toggleConcealAmounts() {
         concealAmounts.toggle()
@@ -112,24 +90,13 @@ class AppState: ObservableObject {
     
     func loadExchangeRates() {
         logger.info("loading exchange rates...")
-        
-        let currencies = Currency.Unit.fiatCases.map { $0.currencyCode.lowercased() }.joined(separator: ",")
-        guard let url = URL(string: "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=\(currencies)") else {
-            logger.warning("could not fetch exchange rates from API due to an invalid URL.")
-            return
-        }
-        
+
         Task {
-            guard let (data, _) = try? await URLSession.shared.data(from: url) else {
+            guard let prices = await Currency.fetchBitcoinExchangeRates() else {
                 logger.warning("unable to load conversion data.")
                 return
             }
-            
-            guard let prices = try? JSONDecoder().decode(ExchangeRateResponse.self, from: data).bitcoin else {
-                logger.warning("unable to decode exchange rate data from request response.")
-                return
-            }
-            
+
             await MainActor.run {
                 self.exchangeRates = prices
             }

--- a/macadamia/Misc/Currency.swift
+++ b/macadamia/Misc/Currency.swift
@@ -8,6 +8,40 @@
 import Foundation
 
 enum Currency {
+    struct ExchangeRate: Decodable, Equatable {
+        let rates: [String: Double]
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            rates = try container.decode([String: Double].self)
+        }
+
+        init(rates: [String: Double]) {
+            self.rates = rates
+        }
+
+        func rate(for unit: Currency.Unit) -> Double? {
+            rates[unit.currencyCode.lowercased()]
+        }
+    }
+
+    private struct ExchangeRateResponse: Decodable {
+        let bitcoin: ExchangeRate
+    }
+
+    static func fetchBitcoinExchangeRates() async -> ExchangeRate? {
+        let currencies = Unit.fiatCases.map { $0.currencyCode.lowercased() }.joined(separator: ",")
+        guard let url = URL(string: "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=\(currencies)") else {
+            return nil
+        }
+
+        guard let (data, _) = try? await URLSession.shared.data(from: url) else {
+            return nil
+        }
+
+        return try? JSONDecoder().decode(ExchangeRateResponse.self, from: data).bitcoin
+    }
+
     struct Amount: Equatable {
         let absoluteValue: Double
         let unit: Unit
@@ -305,13 +339,32 @@ enum Currency {
             try container.encode(currencyCode)
         }
 
-        /// Access the preferred conversion unit directly from UserDefaults without initializing AppState.
+        private static let appGroupID = "group.com.cypherbase.macadamia"
+        private static let preferredConversionUnitKey = "PreferredCurrencyConversionUnit"
+
+        private static var sharedDefaults: UserDefaults {
+            UserDefaults(suiteName: appGroupID) ?? .standard
+        }
+
+        /// Access the preferred conversion unit directly from shared UserDefaults without initializing AppState.
         static var preferred: Unit {
-            let key = "PreferredCurrencyConversionUnit"
-            if let code = UserDefaults.standard.string(forKey: key) {
+            if let code = sharedDefaults.string(forKey: preferredConversionUnitKey) {
                 return Unit(code: code)
             }
             return .usd
+        }
+
+        static func savePreferred(_ unit: Unit) {
+            sharedDefaults.setValue(unit.currencyCode, forKey: preferredConversionUnitKey)
+        }
+
+        static func migratePreferredFromStandardDefaultsIfNeeded() {
+            guard sharedDefaults.object(forKey: preferredConversionUnitKey) == nil,
+                  let code = UserDefaults.standard.string(forKey: preferredConversionUnitKey) else {
+                return
+            }
+
+            sharedDefaults.setValue(code, forKey: preferredConversionUnitKey)
         }
     }
 }

--- a/macadamia/Misc/NumericalInputView.swift
+++ b/macadamia/Misc/NumericalInputView.swift
@@ -18,7 +18,7 @@ struct NumericalInputView: View {
     let baseUnit: Currency.Unit
 
     /// Optional exchange rates - if nil, conversion features are disabled.
-    let exchangeRates: AppState.ExchangeRate?
+    let exchangeRates: Currency.ExchangeRate?
     let onReturn: () -> Void
 
     @State private var input: String = ""

--- a/macadamia/macadamiaMessages/Views/MessageAppUI.swift
+++ b/macadamia/macadamiaMessages/Views/MessageAppUI.swift
@@ -208,22 +208,18 @@ struct MessageSendView: View {
     }
     
     @State private var memo: String = ""
-    @State private var amountString: String = ""
+    @State private var amount = 0
     @State private var buttonState = ActionButtonState.idle("...")
     @State private var mintIcon: UIImage?
     @State private var selectedBanner: String = ""
+    @State private var exchangeRates: Currency.ExchangeRate?
     
-    @FocusState private var amountFieldInFocus
     @ScaledMetric(relativeTo: .body) private var iconSize: CGFloat = 60
     
     private var buttonDisabled: Bool {
         amount <= 0 || amount > mint.balance(for: .sat)
     }
-    
-    private var amount: Int {
-        Int(amountString) ?? 0
-    }
-    
+
     var body: some View {
         ZStack {
             List {
@@ -267,14 +263,10 @@ struct MessageSendView: View {
                 }
                 
                 Section {
-                    HStack {
-                        TextField("Enter amount...", text: $amountString)
-                            .keyboardType(.numberPad)
-                            .focused($amountFieldInFocus)
-                        Spacer()
-                        Text("sat")
-                    }
-                    .monospaced()
+                    NumericalInputView(output: $amount,
+                                       baseUnit: .sat,
+                                       exchangeRates: exchangeRates,
+                                       onReturn: createToken)
                     
                     HStack {
                         Text("Balance: ")
@@ -321,13 +313,20 @@ struct MessageSendView: View {
         }
         .onAppear {
             buttonState = .idle(String(localized: "Send"), action: createToken)
-            amountFieldInFocus = true
+        }
+        .task {
+            guard exchangeRates == nil else { return }
+            exchangeRates = await Currency.fetchBitcoinExchangeRates()
         }
         .navigationTitle("Send")
         .navigationBarTitleDisplayMode(.inline)
     }
     
     private func createToken() {
+        guard !buttonDisabled else {
+            return
+        }
+
         guard let activeWallet else {
             buttonState = .fail(String(localized: "No active wallet"))
             return
@@ -337,7 +336,6 @@ struct MessageSendView: View {
         
         Task {
             do {
-                // iMessage extension is sat-only today.
                 let token = try await AppSchemaV1.createToken(mint: mint,
                                                               activeWallet: activeWallet,
                                                               amount: amount,

--- a/macadamia/macadamiaMessages/Views/MessageAppUI.swift
+++ b/macadamia/macadamiaMessages/Views/MessageAppUI.swift
@@ -316,6 +316,7 @@ struct MessageSendView: View {
         }
         .task {
             guard exchangeRates == nil else { return }
+            guard Currency.Unit.preferred.kind == .fiat else { return }
             exchangeRates = await Currency.fetchBitcoinExchangeRates()
         }
         .navigationTitle("Send")


### PR DESCRIPTION
Closes #67

The iMessage send flow was sat-only. This brings it in line with the main
app so users can enter an amount in their preferred fiat currency and have
it converted to sats.

### Changes
- Replace the sat-only `TextField` with `NumericalInputView`, the same
  amount-entry component the main app uses (fiat entry + live sat conversion).
- Share the preferred currency between the app and the iMessage extension via
  the existing `group.com.cypherbase.macadamia` app group (both targets already
  declare the entitlement), so the setting stays in sync.
- Lift the exchange-rate fetch/decode out of `AppState` into
  `Currency.fetchBitcoinExchangeRates()` and reuse it from both targets
  (no duplicated logic).
- Migrate any existing `PreferredCurrencyConversionUnit` value from standard
  defaults into the shared store on launch, so current users keep their setting.
- Only fetch exchange rates in the extension when the preferred unit is fiat.

### Testing
Happy to adjust based on review. Worth a build of both the app and the
macadamiaMessages extension and a quick run through the iMessage send flow
with a fiat preference set to confirm conversion and token creation.

----
- [x] I made sure to choose branch RELEASE as the target for this pull request
