### PR TITLE
Support all advertised payment methods with generic mint and melt quotes

### DIFF
--- a/macadamia.xcodeproj/project.pbxproj
+++ b/macadamia.xcodeproj/project.pbxproj
@@ -855,7 +855,7 @@
 			repositoryURL = "https://github.com/zeugmaster/cashu-swift.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.1;
+				minimumVersion = 0.4.3;
 			};
 		};
 		377D26242E1FDE7800CFB880 /* XCRemoteSwiftPackageReference "URUI" */ = {

--- a/macadamia.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/macadamia.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/zeugmaster/cashu-swift.git",
       "state" : {
-        "revision" : "873dcf929b2768a0fff4948cf3e767d9e3685a78",
-        "version" : "0.4.1"
+        "revision" : "1199678da6c1a34f4220182461b73901002ca02c",
+        "version" : "0.4.3"
       }
     },
     {

--- a/macadamia/AppAssets/Localizable.xcstrings
+++ b/macadamia/AppAssets/Localizable.xcstrings
@@ -732,6 +732,986 @@
     "%lld%%" : {
       "shouldTranslate" : false
     },
+    "Amount Mismatch" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عدم تطابق المبلغ"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "পরিমাণ মেলেনি"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Betrag stimmt nicht überein"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El monto no coincide"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Montant non concordant"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "राशि मेल नहीं खाती"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "金額の不一致"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "금액 불일치"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Divergência de valor"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Несовпадение суммы"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutar uyuşmazlığı"
+          }
+        }
+      }
+    },
+    "Get Quote" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الحصول على عرض السعر"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "কোট পান"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quote erhalten"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obtener cotización"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obtenir un devis"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "कोट प्राप्त करें"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クォートを取得"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "견적 받기"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obter cotação"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Получить предложение"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Teklif al"
+          }
+        }
+      }
+    },
+    "Memo (optional)" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ملاحظة (اختياري)"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "মেমো (ঐচ্ছিক)"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beschreibung (optional)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nota (opcional)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mémo (facultatif)"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "मेमो (वैकल्पिक)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メモ（任意）"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "메모 (선택 사항)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nota (opcional)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Заметка (необязательно)"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not (isteğe bağlı)"
+          }
+        }
+      }
+    },
+    "Method" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الطريقة"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "পদ্ধতি"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Methode"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Método"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Méthode"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "विधि"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "方法"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "방법"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Método"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Метод"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yöntem"
+          }
+        }
+      }
+    },
+    "Other Withdrawal Methods" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "طرق سحب أخرى"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "অন্যান্য উত্তোলন পদ্ধতি"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weitere Abhebungsmethoden"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Otros métodos de retiro"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autres méthodes de retrait"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "अन्य निकासी विधियाँ"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "その他の出金方法"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "기타 출금 방법"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Outros métodos de saque"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Другие способы вывода"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diğer para çekme yöntemleri"
+          }
+        }
+      }
+    },
+    "Pending Withdrawal" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سحب معلق"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "অমীমাংসিত উত্তোলন"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ausstehende Abhebung"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retiro pendiente"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retrait en attente"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "लंबित निकासी"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保留中の出金"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "대기 중인 출금"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saque pendente"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ожидающий вывод"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bekleyen para çekme"
+          }
+        }
+      }
+    },
+    "Request Quote" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "طلب عرض السعر"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "কোট অনুরোধ করুন"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quote anfordern"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solicitar cotización"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Demander un devis"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "कोट का अनुरोध करें"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "クォートを取得"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "견적 요청"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Solicitar cotação"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запросить предложение"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Teklif iste"
+          }
+        }
+      }
+    },
+    "The mint reported this withdrawal as failed. Your ecash has been returned to your balance." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أبلغ المينت أن هذا السحب قد فشل. تمت إعادة الإيكاش إلى رصيدك."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "মিন্ট এই উত্তোলনটি ব্যর্থ বলে জানিয়েছে। আপনার ইক্যাশ আপনার ব্যালেন্সে ফেরত দেওয়া হয়েছে।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Mint hat diese Abhebung als fehlgeschlagen gemeldet. Dein Ecash wurde deinem Guthaben wieder gutgeschrieben."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El mint informó que este retiro falló. Tu ecash ha sido devuelto a tu saldo."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le mint a signalé l'échec de ce retrait. Ton ecash a été recrédité sur ton solde."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "मिंट ने इस निकासी को विफल बताया है। आपका ईकैश आपके बैलेंस में वापस कर दिया गया है।"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ミントがこの出金を失敗として報告しました。ecashは残高に戻されました。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "민트가 이 출금을 실패로 보고했습니다. 이캐시가 잔액으로 반환되었습니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O mint informou que este saque falhou. Seu ecash foi devolvido ao seu saldo."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Минт сообщил, что этот вывод не удался. Твой ecash возвращён на баланс."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mint bu para çekme işlemini başarısız olarak bildirdi. Ecash bakiyene iade edildi."
+          }
+        }
+      }
+    },
+    "The mint's quote amount does not match the requested amount." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مبلغ عرض السعر من المينت لا يطابق المبلغ المطلوب."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "মিন্টের কোটের পরিমাণ অনুরোধ করা পরিমাণের সাথে মিলছে না।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Betrag der Quote der Mint stimmt nicht mit dem angeforderten Betrag überein."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "El monto de la cotización del mint no coincide con el monto solicitado."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le montant du devis du mint ne correspond pas au montant demandé."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "मिंट के कोट की राशि अनुरोधित राशि से मेल नहीं खाती।"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ミントのクォート金額がリクエストした金額と一致しません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "민트의 견적 금액이 요청한 금액과 일치하지 않습니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O valor da cotação do mint não corresponde ao valor solicitado."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сумма предложения минта не совпадает с запрошенной суммой."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mint'in teklif tutarı istenen tutarla eşleşmiyor."
+          }
+        }
+      }
+    },
+    "The state of this withdrawal could not be determined. Please check again later." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تعذر تحديد حالة هذا السحب. يرجى التحقق مرة أخرى لاحقًا."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "এই উত্তোলনের অবস্থা নির্ধারণ করা যায়নি। অনুগ্রহ করে পরে আবার চেক করুন।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Status dieser Abhebung konnte nicht ermittelt werden. Bitte später erneut prüfen."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No se pudo determinar el estado de este retiro. Verifica de nuevo más tarde."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'état de ce retrait n'a pas pu être déterminé. Réessaie plus tard."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "इस निकासी की स्थिति निर्धारित नहीं की जा सकी। कृपया बाद में फिर से जांचें।"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この出金の状態を確認できませんでした。後でもう一度確認してください。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 출금의 상태를 확인할 수 없습니다. 나중에 다시 확인해 주세요."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não foi possível determinar o estado deste saque. Verifique novamente mais tarde."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не удалось определить статус этого вывода. Проверь позже ещё раз."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu para çekme işleminin durumu belirlenemedi. Lütfen daha sonra tekrar kontrol et."
+          }
+        }
+      }
+    },
+    "Waiting for the mint operator to confirm the payout. This can take a few minutes." : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "في انتظار تأكيد مشغّل المينت للدفعة. قد يستغرق ذلك بضع دقائق."
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "মিন্ট অপারেটরের পেমেন্ট নিশ্চিতকরণের জন্য অপেক্ষা করা হচ্ছে। এতে কয়েক মিনিট লাগতে পারে।"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Warte auf die Bestätigung der Auszahlung durch den Betreiber der Mint. Dies kann einige Minuten dauern."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esperando a que el operador del mint confirme el pago. Esto puede tardar unos minutos."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En attente de la confirmation du paiement par l'opérateur du mint. Cela peut prendre quelques minutes."
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "मिंट ऑपरेटर द्वारा भुगतान की पुष्टि की प्रतीक्षा है। इसमें कुछ मिनट लग सकते हैं।"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ミントのオペレーターによる支払い確認を待っています。数分かかることがあります。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "민트 운영자의 지급 확인을 기다리는 중입니다. 몇 분 정도 걸릴 수 있습니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aguardando o operador do mint confirmar o pagamento. Isso pode levar alguns minutos."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ожидание подтверждения выплаты оператором минта. Это может занять несколько минут."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mint operatörünün ödemeyi onaylaması bekleniyor. Bu birkaç dakika sürebilir."
+          }
+        }
+      }
+    },
+    "Withdraw" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سحب"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "উত্তোলন"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abheben"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retirar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retirer"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "निकासी करें"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "出金"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "출금"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sacar"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вывести"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Çek"
+          }
+        }
+      }
+    },
+    "Withdrawal" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "السحب"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "উত্তোলন"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abhebung"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retiro"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retrait"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "निकासी"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "出金"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "출금"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saque"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вывод средств"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Para çekme"
+          }
+        }
+      }
+    },
+    "Withdrawal Failed" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "فشل السحب"
+          }
+        },
+        "bn" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "উত্তোলন ব্যর্থ হয়েছে"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abhebung fehlgeschlagen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retiro fallido"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échec du retrait"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "निकासी विफल"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "出金に失敗しました"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "출금 실패"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Falha no saque"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вывод не удался"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Para çekme başarısız"
+          }
+        }
+      }
+    },
     "• Allocation:" : {
       "localizations" : {
         "ar" : {

--- a/macadamia/Misc/PaymentOptionPicker.swift
+++ b/macadamia/Misc/PaymentOptionPicker.swift
@@ -4,6 +4,8 @@ struct PaymentOptionPicker: View {
     let direction: PaymentDirection
     let label: String
     let allowedMethods: Set<PaymentMethodKind>?
+    let excludedMethods: Set<PaymentMethodKind>?
+    let hidesWhenSingleOption: Bool
 
     @Binding var selectedMint: Mint?
     @Binding var selectedOption: PaymentOption?
@@ -15,12 +17,16 @@ struct PaymentOptionPicker: View {
          label: String = String(localized: "Payment"),
          selectedMint: Binding<Mint?>,
          selectedOption: Binding<PaymentOption?>,
-         allowedMethods: Set<PaymentMethodKind>? = nil) {
+         allowedMethods: Set<PaymentMethodKind>? = nil,
+         excludedMethods: Set<PaymentMethodKind>? = nil,
+         hidesWhenSingleOption: Bool = true) {
         self.direction = direction
         self.label = label
         self._selectedMint = selectedMint
         self._selectedOption = selectedOption
         self.allowedMethods = allowedMethods
+        self.excludedMethods = excludedMethods
+        self.hidesWhenSingleOption = hidesWhenSingleOption
     }
 
     var body: some View {
@@ -41,7 +47,16 @@ struct PaymentOptionPicker: View {
                         .foregroundStyle(.secondary)
                 }
             } else if distinctOptionCount <= 1 {
-                EmptyView()
+                if hidesWhenSingleOption {
+                    EmptyView()
+                } else {
+                    HStack {
+                        Text(label)
+                        Spacer()
+                        Text(selectedOption?.displayName ?? options.first?.displayName ?? "")
+                            .foregroundStyle(.secondary)
+                    }
+                }
             } else {
                 Picker(label, selection: $selectedOption) {
                     ForEach(options) { option in
@@ -59,7 +74,9 @@ struct PaymentOptionPicker: View {
     }
 
     private var refreshID: String {
-        "\(selectedMint?.mintID.uuidString ?? "nil")|\(direction.rawValue)|\(allowedMethods?.map(\.rawValue).sorted().joined(separator: ",") ?? "all")"
+        let allowed = allowedMethods?.map(\.rawValue).sorted().joined(separator: ",") ?? "all"
+        let excluded = excludedMethods?.map(\.rawValue).sorted().joined(separator: ",") ?? "none"
+        return "\(selectedMint?.mintID.uuidString ?? "nil")|\(direction.rawValue)|\(allowed)|\(excluded)"
     }
 
     private var distinctOptionCount: Int {
@@ -76,11 +93,14 @@ struct PaymentOptionPicker: View {
 
         isLoading = true
         let loadedOptions = await selectedMint.supportedPaymentOptions(direction: direction)
-        let filteredOptions: [PaymentOption]
+        var filteredOptions: [PaymentOption]
         if let allowedMethods {
             filteredOptions = loadedOptions.filter { allowedMethods.contains($0.method) }
         } else {
             filteredOptions = loadedOptions
+        }
+        if let excludedMethods {
+            filteredOptions = filteredOptions.filter { !excludedMethods.contains($0.method) }
         }
 
         let previous = selectedOption

--- a/macadamia/PersistentModelV1/EventFactory.swift
+++ b/macadamia/PersistentModelV1/EventFactory.swift
@@ -250,6 +250,104 @@ extension AppSchemaV1.Event {
         event.toMint = to
         return event
     }
+
+    // MARK: - Generic (non-BOLT11) payment methods
+
+    static func pendingMintEvent(unit: Unit,
+                                 shortDescription: String,
+                                 visible: Bool = true,
+                                 wallet: Wallet,
+                                 genericQuote: CashuSwift.Generic.MintQuote,
+                                 amount: Int,
+                                 expiration: Date?,
+                                 mint: Mint) -> Event {
+        assert(!genericQuote.method.rawValue.isEmpty, "a generic mint quote must carry its payment method")
+        let event = Event(date: Date(),
+                          unit: unit,
+                          shortDescription: shortDescription,
+                          visible: visible,
+                          kind: .pendingMint,
+                          wallet: wallet,
+                          amount: amount,
+                          expiration: expiration,
+                          mints: [mint])
+        event.genericMintQuote = genericQuote
+        return event
+    }
+
+    static func mintEvent(unit: Unit,
+                          shortDescription: String,
+                          visible: Bool = true,
+                          wallet: Wallet,
+                          genericQuote: CashuSwift.Generic.MintQuote,
+                          mint: Mint,
+                          amount: Int) -> Event {
+        assert(!genericQuote.method.rawValue.isEmpty, "a generic mint quote must carry its payment method")
+        let event = Event(date: Date(),
+                          unit: unit,
+                          shortDescription: shortDescription,
+                          visible: visible,
+                          kind: .mint,
+                          wallet: wallet,
+                          amount: amount,
+                          mints: [mint])
+        event.genericMintQuote = genericQuote
+        return event
+    }
+
+    static func pendingMeltEvent(unit: Unit,
+                                 shortDescription: String,
+                                 visible: Bool = true,
+                                 wallet: Wallet,
+                                 genericQuote: CashuSwift.Generic.MeltQuote,
+                                 amount: Int,
+                                 expiration: Date?,
+                                 mints: [Mint],
+                                 proofs: [Proof]? = nil,
+                                 memo: String? = nil) -> Event {
+        assert(!genericQuote.method.rawValue.isEmpty, "a generic melt quote must carry its payment method")
+        let event = Event(date: Date(),
+                          unit: unit,
+                          shortDescription: shortDescription,
+                          visible: visible,
+                          kind: .pendingMelt,
+                          wallet: wallet,
+                          amount: amount,
+                          expiration: expiration,
+                          proofs: proofs,
+                          memo: memo,
+                          mints: mints)
+        event.genericMeltQuote = genericQuote
+        return event
+    }
+
+    static func meltEvent(unit: Unit,
+                          shortDescription: String,
+                          visible: Bool = true,
+                          wallet: Wallet,
+                          amount: Int,
+                          longDescription: String,
+                          mints: [Mint],
+                          change: [Proof]? = nil,
+                          preImage: String? = nil,
+                          memo: String? = nil,
+                          genericQuote: CashuSwift.Generic.MeltQuote) -> Event {
+        assert(!genericQuote.method.rawValue.isEmpty, "a generic melt quote must carry its payment method")
+        let event = Event(date: Date(),
+                          unit: unit,
+                          shortDescription: shortDescription,
+                          visible: visible,
+                          kind: .melt,
+                          wallet: wallet,
+                          amount: amount,
+                          longDescription: longDescription,
+                          proofs: change,
+                          memo: memo,
+                          mints: mints,
+                          preImage: preImage)
+        event.genericMeltQuote = genericQuote
+        return event
+    }
 }
 
 extension AppSchemaV1.Event {

--- a/macadamia/PersistentModelV1/Operations/getQuote.swift
+++ b/macadamia/PersistentModelV1/Operations/getQuote.swift
@@ -68,4 +68,56 @@ extension AppSchemaV1.Mint {
             }
         }
     }
+
+    /// Requests a mint quote for a non-BOLT11 payment method via the generic
+    /// endpoint. Every quote is locked to a fresh NUT-20 key derived from the
+    /// wallet seed: harmless at mints that ignore the field, required by mints
+    /// that enforce locking. The key's derivation counter is grafted into the
+    /// quote before it is handed out so issuance can re-derive the key, also
+    /// after an app restart.
+    @MainActor
+    func getGenericMintQuote(method: PaymentMethodKind,
+                             unit unitCode: String,
+                             amount: Int,
+                             completion: @escaping (Result<(quote: CashuSwift.Generic.MintQuote,
+                                                            event: Event), Error>) -> Void) {
+
+        guard let wallet = self.wallet else {
+            completion(.failure(macadamiaError.databaseError("mint \(self.url.absoluteString) does not have an associated wallet.")))
+            return
+        }
+
+        let sendableMint = CashuSwift.Mint(self)
+        let seed = wallet.seed
+
+        Task {
+            do {
+                let counter = UInt32.random(in: 0..<UInt32.max)
+                let key = try CashuSwift.Generic.quoteLockingKey(seed: seed, counter: counter)
+
+                let quoteRequest = CashuSwift.Generic.MintQuoteRequest(method: method.id,
+                                                                       unit: unitCode,
+                                                                       amount: amount,
+                                                                       extra: ["pubkey": .string(key.publicKey)])
+
+                let quote = try await CashuSwift.Generic.requestMintQuote(quoteRequest, from: sendableMint)
+                    .addingNut20Counter(counter)
+
+                await MainActor.run {
+                    let event = Event.pendingMintEvent(unit: Unit(code: quote.unit),
+                                                       shortDescription: "Mint Quote",
+                                                       wallet: wallet,
+                                                       genericQuote: quote,
+                                                       amount: quote.amount ?? amount,
+                                                       expiration: quote.expiry.map { Date(timeIntervalSince1970: TimeInterval($0)) },
+                                                       mint: self)
+                    completion(.success((quote, event)))
+                }
+            } catch {
+                await MainActor.run {
+                    completion(.failure(error))
+                }
+            }
+        }
+    }
 }

--- a/macadamia/PersistentModelV1/PaymentOption.swift
+++ b/macadamia/PersistentModelV1/PaymentOption.swift
@@ -185,3 +185,163 @@ extension Array where Element == PaymentOption {
         return first
     }
 }
+
+/// A mint quote in either its first-class BOLT11 shape or the method-agnostic
+/// generic shape used for every other advertised payment method (e.g. "branch").
+enum MintQuoteVariant {
+    case bolt11(CashuSwift.Bolt11.MintQuote)
+    case generic(CashuSwift.Generic.MintQuote)
+
+    var quoteID: String {
+        switch self {
+        case .bolt11(let quote): return quote.quote
+        case .generic(let quote): return quote.quote
+        }
+    }
+
+    var request: String {
+        switch self {
+        case .bolt11(let quote): return quote.request
+        case .generic(let quote): return quote.request
+        }
+    }
+
+    var unitCode: String {
+        switch self {
+        case .bolt11(let quote): return quote.unit
+        case .generic(let quote): return quote.unit
+        }
+    }
+
+    var amount: Int? {
+        switch self {
+        case .bolt11(let quote): return quote.amount
+        case .generic(let quote): return quote.amount
+        }
+    }
+
+    var expiry: Int? {
+        switch self {
+        case .bolt11(let quote): return quote.expiry
+        case .generic(let quote): return quote.expiry
+        }
+    }
+
+    var method: PaymentMethodKind {
+        switch self {
+        case .bolt11: return .bolt11
+        case .generic(let quote): return PaymentMethodKind(quote.method)
+        }
+    }
+
+    var bolt11Quote: CashuSwift.Bolt11.MintQuote? {
+        if case .bolt11(let quote) = self { return quote }
+        return nil
+    }
+
+    var genericQuote: CashuSwift.Generic.MintQuote? {
+        if case .generic(let quote) = self { return quote }
+        return nil
+    }
+}
+
+extension CashuSwift.Generic.MintQuote {
+    /// Key under which the wallet stores the NUT-20 locking-key counter inside
+    /// the quote's raw JSON so it round-trips through local persistence. Never
+    /// sent to the mint: execution bodies are built from quote ID and outputs
+    /// only, and `encode(to:)` is used solely for local storage.
+    static let nut20CounterKey = "macadamia_nut20_counter"
+
+    var nut20Counter: UInt32? {
+        if case let .integer(value) = raw[Self.nut20CounterKey] ?? .null {
+            return UInt32(exactly: value)
+        }
+        return nil
+    }
+
+    /// A copy with the locking-key counter grafted into `raw`. Must be applied
+    /// before the quote is persisted or held in view state.
+    func addingNut20Counter(_ counter: UInt32) -> CashuSwift.Generic.MintQuote {
+        var newRaw = raw
+        newRaw[Self.nut20CounterKey] = .integer(Int64(counter))
+        return CashuSwift.Generic.MintQuote(method: method,
+                                            quote: quote,
+                                            request: request,
+                                            unit: unit,
+                                            amount: amount,
+                                            state: state,
+                                            expiry: expiry,
+                                            raw: newRaw)
+    }
+
+    /// The NUT-20 pubkey the mint echoed in the quote — its presence means the
+    /// quote is locked and issuance must be signed.
+    var lockingPubkey: String? {
+        if case let .string(pubkey) = raw["pubkey"] ?? .null { return pubkey }
+        return nil
+    }
+
+    var amountPaid: Int? {
+        switch raw["amount_paid"] {
+        case .integer(let value): return Int(value)
+        case .double(let value): return Int(value)
+        default: return nil
+        }
+    }
+
+    var amountIssued: Int? {
+        switch raw["amount_issued"] {
+        case .integer(let value): return Int(value)
+        case .double(let value): return Int(value)
+        default: return nil
+        }
+    }
+
+    /// Whether the mint reports this quote as payable into ecash. Methods
+    /// without a typed state (e.g. "branch") express progress through
+    /// `amount_paid` instead.
+    var indicatesPaid: Bool {
+        if state == .paid { return true }
+        if case let .string(stateString) = raw["state"] ?? .null, stateString.uppercased() == "PAID" { return true }
+        if let amountPaid, let amount { return amountPaid >= amount }
+        return false
+    }
+
+    var indicatesIssued: Bool {
+        if state == .issued { return true }
+        if case let .string(stateString) = raw["state"] ?? .null, stateString.uppercased() == "ISSUED" { return true }
+        if let amountIssued, let amount { return amountIssued >= amount }
+        return false
+    }
+}
+
+extension CashuSwift.Generic.MeltQuote {
+    /// Raw state string from the mint. `QuoteState` models only
+    /// UNPAID/PENDING/PAID/ISSUED; custom backends also emit e.g. FAILED or
+    /// UNKNOWN, which decode to `state == nil` but stay readable here.
+    var rawStateString: String? {
+        if case let .string(stateString) = raw["state"] ?? .null { return stateString }
+        return nil
+    }
+
+    var isFailed: Bool { rawStateString?.uppercased() == "FAILED" }
+
+    /// A copy with `method` set and grafted into `raw`. Results from
+    /// `Generic.melt` / `Generic.meltState` carry no method (the mint does not
+    /// echo it and the library only injects it on quote creation), so quotes
+    /// must pass through this before being persisted.
+    func settingMethod(_ method: CashuSwift.PaymentMethodID) -> CashuSwift.Generic.MeltQuote {
+        var newRaw = raw
+        newRaw["method"] = .string(method.rawValue)
+        return CashuSwift.Generic.MeltQuote(method: method,
+                                            quote: quote,
+                                            amount: amount,
+                                            unit: unit,
+                                            feeReserve: feeReserve,
+                                            state: state,
+                                            expiry: expiry,
+                                            paymentPreimage: paymentPreimage,
+                                            change: change,
+                                            raw: newRaw)
+    }
+}

--- a/macadamia/PersistentModelV1/PersistentModelV1.swift
+++ b/macadamia/PersistentModelV1/PersistentModelV1.swift
@@ -514,6 +514,13 @@ enum AppSchemaV1: VersionedSchema {
         var mintQuote: CashuSwift.Bolt11.MintQuote? {
             get {
                 if let bolt11MintQuoteData {
+                    // A generic quote's stored JSON would also decode as a BOLT11 quote
+                    // (unknown keys are ignored), so route on the persisted method first:
+                    // BOLT11 rows never contain a `method` key, generic rows always do.
+                    if let method = (try? JSONDecoder().decode(StoredQuoteMethodProbe.self, from: bolt11MintQuoteData))?.method,
+                       method != PaymentMethodKind.bolt11.rawValue {
+                        return nil
+                    }
                     return try? JSONDecoder().decode(CashuSwift.Bolt11.MintQuote.self, from: bolt11MintQuoteData)
                 }
                 // Fall back to the legacy composite for rows migrated from the App Store build.
@@ -525,9 +532,32 @@ enum AppSchemaV1: VersionedSchema {
             }
         }
 
+        var genericMintQuote: CashuSwift.Generic.MintQuote? {
+            get {
+                guard let bolt11MintQuoteData,
+                      let quote = try? JSONDecoder().decode(CashuSwift.Generic.MintQuote.self, from: bolt11MintQuoteData),
+                      !quote.method.rawValue.isEmpty,
+                      quote.method.rawValue != PaymentMethodKind.bolt11.rawValue else {
+                    return nil
+                }
+                return quote
+            }
+            set {
+                bolt11MintQuoteData = newValue.flatMap { try? JSONEncoder().encode($0) }
+                bolt11MintQuote = nil // vacate the legacy slot once rewritten
+            }
+        }
+
         var bolt11MeltQuote: CashuSwift.Bolt11.MeltQuote? {
             get {
                 guard let data = bolt11MeltQuoteData else { return nil }
+                // A generic quote's stored JSON would also decode through one of the
+                // BOLT11 shapes below, so route on the persisted method first: BOLT11
+                // rows never contain a `method` key, generic rows always do.
+                if let method = (try? JSONDecoder().decode(StoredQuoteMethodProbe.self, from: data))?.method,
+                   method != PaymentMethodKind.bolt11.rawValue {
+                    return nil
+                }
                 // Current shape first. Rows written before the cashu-swift payment-method
                 // namespace overhaul stored `unit`/`request` inside a nested `quoteRequest`
                 // and had no top-level `unit`, so the current decoder throws on them; fall
@@ -539,6 +569,21 @@ enum AppSchemaV1: VersionedSchema {
             }
             set {
                 bolt11MeltQuoteData = try? JSONEncoder().encode(newValue)
+            }
+        }
+
+        var genericMeltQuote: CashuSwift.Generic.MeltQuote? {
+            get {
+                guard let data = bolt11MeltQuoteData,
+                      let quote = try? JSONDecoder().decode(CashuSwift.Generic.MeltQuote.self, from: data),
+                      !quote.method.rawValue.isEmpty,
+                      quote.method.rawValue != PaymentMethodKind.bolt11.rawValue else {
+                    return nil
+                }
+                return quote
+            }
+            set {
+                bolt11MeltQuoteData = newValue.flatMap { try? JSONEncoder().encode($0) }
             }
         }
         
@@ -583,6 +628,15 @@ enum AppSchemaV1: VersionedSchema {
         func tuple() -> (outputs: [CashuSwift.Output], blindingFactors: [String], secrets: [String]) {
             (outputs, blindingFactors, secrets)
         }
+    }
+
+    /// Decodes only the `method` key of a stored quote blob, to route between the
+    /// BOLT11-typed and generic accessors. Rows written from BOLT11 quotes (current
+    /// shape and the legacy mirrors) never contain a `method` key — it is a computed
+    /// property excluded from their CodingKeys — while generic-method rows always
+    /// do: the library grafts the method into the quote's raw JSON on creation.
+    fileprivate struct StoredQuoteMethodProbe: Decodable {
+        let method: String?
     }
 
     /// All-optional mirror of the persisted `CashuSwift.Bolt11.MintQuote` columns, used as the

--- a/macadamia/Settings/EventInspectorView.swift
+++ b/macadamia/Settings/EventInspectorView.swift
@@ -104,6 +104,33 @@ struct EventDataView: View {
                 }
             }
 
+            if let genericQuote = event.genericMintQuote {
+                Section("Mint Quote") {
+                    CopyableRow(label: "Quote ID", value: genericQuote.quote)
+                    CopyableRow(label: "Method", value: genericQuote.method.rawValue)
+                    if let state = genericQuote.state {
+                        CopyableRow(label: "State", value: state.rawValue)
+                    }
+                    if let amount = genericQuote.amount {
+                        CopyableRow(label: "Amount", value: "\(amount) \(genericQuote.unit)")
+                    }
+                    if let amountPaid = genericQuote.amountPaid {
+                        CopyableRow(label: "Amount Paid", value: String(amountPaid))
+                    }
+                    if let amountIssued = genericQuote.amountIssued {
+                        CopyableRow(label: "Amount Issued", value: String(amountIssued))
+                    }
+                    CopyableRow(label: "Payment Request", value: genericQuote.request)
+                    if let counter = genericQuote.nut20Counter {
+                        CopyableRow(label: "NUT-20 Counter", value: String(counter))
+                    }
+                    if let expiry = genericQuote.expiry {
+                        CopyableRow(label: "Expiry",
+                                    value: Date(timeIntervalSince1970: TimeInterval(expiry)).formatted())
+                    }
+                }
+            }
+
             if let meltQuote = event.bolt11MeltQuote {
                 Section("Melt Quote") {
                     CopyableRow(label: "Quote ID", value: meltQuote.quote)
@@ -121,6 +148,25 @@ struct EventDataView: View {
                     }
                     if let preimage = meltQuote.paymentPreimage, !preimage.isEmpty {
                         CopyableRow(label: "Payment Preimage", value: preimage)
+                    }
+                }
+            }
+
+            if let genericQuote = event.genericMeltQuote {
+                Section("Melt Quote") {
+                    CopyableRow(label: "Quote ID", value: genericQuote.quote)
+                    CopyableRow(label: "Method", value: genericQuote.method.rawValue)
+                    if let state = genericQuote.rawStateString {
+                        CopyableRow(label: "State", value: state)
+                    }
+                    CopyableRow(label: "Amount", value: "\(genericQuote.amount) \(genericQuote.unit)")
+                    CopyableRow(label: "Fee Reserve", value: String(genericQuote.feeReserve))
+                    if let expiry = genericQuote.expiry {
+                        CopyableRow(label: "Expiry",
+                                    value: Date(timeIntervalSince1970: TimeInterval(expiry)).formatted())
+                    }
+                    if let preimage = genericQuote.paymentPreimage, !preimage.isEmpty {
+                        CopyableRow(label: "Payment Note", value: preimage)
                     }
                 }
             }

--- a/macadamia/Wallet/Events/EventList.swift
+++ b/macadamia/Wallet/Events/EventList.swift
@@ -326,7 +326,13 @@ struct EventList: View {
         case .pendingReceive:
             if let e = group.events.first { RedeemLaterView(event: e) } else { Text("No pending receive event provided.") }
         case .pendingMelt:
-            MeltView(events: group.events)
+            // Generic (non-BOLT11) melts are single events with their own flow;
+            // BOLT11 payments (incl. MPP groups) resume in MeltView.
+            if let e = group.events.first, e.genericMeltQuote != nil {
+                GenericMeltView(pendingEvent: e)
+            } else {
+                MeltView(events: group.events)
+            }
         case .melt:
             MeltEventSummary(events: group.events)
         case .restore:

--- a/macadamia/Wallet/Events/EventSummary.swift
+++ b/macadamia/Wallet/Events/EventSummary.swift
@@ -34,6 +34,9 @@ struct MintEventSummary: View {
                 if let text = event.mintQuote?.request {
                     CopyableRow(label: "Bolt11 Invoice", value: text)
                         .foregroundStyle(.secondary)
+                } else if let genericQuote = event.genericMintQuote {
+                    CopyableRow(label: String(localized: "Payment Request"), value: genericQuote.request)
+                        .foregroundStyle(.secondary)
                 }
             }
             
@@ -59,7 +62,7 @@ struct MintEventSummary: View {
                 }
                 
                 if showDetails {
-                    CopyableRow(label: "Quote ID", value: event.mintQuote?.quote ?? "nil")
+                    CopyableRow(label: "Quote ID", value: event.mintQuote?.quote ?? event.genericMintQuote?.quote ?? "nil")
                 }
             }
         }
@@ -158,7 +161,8 @@ struct MeltEventSummary: View {
                 
                 if showDetails {
                     ForEach(events) { event in
-                        CopyableRow(label: (event.mints?.first?.displayName ?? "nil") + " - Quote ID", value: event.bolt11MeltQuote?.quote ?? "nil")
+                        CopyableRow(label: (event.mints?.first?.displayName ?? "nil") + " - Quote ID",
+                                    value: event.bolt11MeltQuote?.quote ?? event.genericMeltQuote?.quote ?? "nil")
                     }
                     CopyableRow(label: "Preimage", value: events.first?.preImage ?? "nil")
                 }

--- a/macadamia/Wallet/MintView.swift
+++ b/macadamia/Wallet/MintView.swift
@@ -7,7 +7,7 @@ struct MintView: View {
     @State private var buttonState: ActionButtonState
     @EnvironmentObject private var appState: AppState
 
-    @State var quote: CashuSwift.Bolt11.MintQuote?
+    @State var quote: MintQuoteVariant?
     @State var pendingMintEvent: Event?
 
     @Environment(\.modelContext) private var modelContext
@@ -38,23 +38,27 @@ struct MintView: View {
 
     init(pendingMintEvent: Event? = nil) {
 
-        _quote = State(initialValue: pendingMintEvent?.mintQuote)
+        let variant: MintQuoteVariant? =
+            pendingMintEvent?.mintQuote.map(MintQuoteVariant.bolt11)
+            ?? pendingMintEvent?.genericMintQuote.map(MintQuoteVariant.generic)
+
+        _quote = State(initialValue: variant)
         _pendingMintEvent = State(initialValue: pendingMintEvent)
         _buttonState = State(initialValue: .idle(String(localized: "No Action")))
 
         if let mint = pendingMintEvent?.mints?.first {
             _selectedMint = State(initialValue: mint)
-            if let quote = pendingMintEvent?.mintQuote {
+            if let variant {
                 _selectedOption = State(initialValue: PaymentOption(mintID: mint.mintID,
                                                                     direction: .mint,
-                                                                    unit: Unit(code: quote.unit),
-                                                                    method: .bolt11))
+                                                                    unit: Unit(code: variant.unitCode),
+                                                                    method: variant.method))
             }
         }
 
-        if let quote = pendingMintEvent?.mintQuote {
-            _amount = State(initialValue: quote.amount ?? 0)
-            _selectedUnit = State(initialValue: Unit(code: quote.unit))
+        if let variant {
+            _amount = State(initialValue: variant.amount ?? pendingMintEvent?.amount ?? 0)
+            _selectedUnit = State(initialValue: Unit(code: variant.unitCode))
         }
     }
 
@@ -72,8 +76,7 @@ struct MintView: View {
                     PaymentOptionPicker(direction: .mint,
                                         label: String(localized: "Unit"),
                                         selectedMint: $selectedMint,
-                                        selectedOption: $selectedOption,
-                                        allowedMethods: [.bolt11])
+                                        selectedOption: $selectedOption)
                 }
                 .disabled(pendingMintEvent != nil)
                 if let quote {
@@ -133,7 +136,7 @@ struct MintView: View {
                         }
 
                         if showDetails {
-                            CopyableRow(label: String(localized: "Quote ID"), value: quote.quote)
+                            CopyableRow(label: String(localized: "Quote ID"), value: quote.quoteID)
                         }
                     }
                 }
@@ -146,7 +149,7 @@ struct MintView: View {
                 if quote != nil {
                     buttonState = .idle(String(localized: "Issue"), action: requestMint)
                 } else {
-                    buttonState = .idle(String(localized: "Get Invoice"), action: getQuote)
+                    buttonState = .idle(getQuoteButtonLabel, action: getQuote)
                 }
             }
             .onChange(of: selectedMint, { oldValue, newValue in
@@ -157,6 +160,11 @@ struct MintView: View {
             .onChange(of: selectedOption) { _, newValue in
                 if let unit = newValue?.unit {
                     selectedUnit = unit
+                }
+                // The picker loads options asynchronously, so the idle label has
+                // to follow the selected method reactively.
+                if quote == nil, buttonState.type == .idle {
+                    buttonState = .idle(getQuoteButtonLabel, action: getQuote)
                 }
             }
             .onDisappear {
@@ -177,6 +185,12 @@ struct MintView: View {
             return amount < 1 || selectedMint == nil || selectedOption == nil
         }
         return selectedMint == nil
+    }
+
+    private var getQuoteButtonLabel: String {
+        selectedOption == nil || selectedOption?.method == .bolt11
+            ? String(localized: "Get Invoice")
+            : String(localized: "Request Quote")
     }
 
     private func copyToClipboard() {
@@ -208,30 +222,44 @@ struct MintView: View {
             return
         }
 
-        let quoteRequest = CashuSwift.Bolt11.MintQuoteRequest(unit: selectedOption.unit.currencyCode.lowercased(),
-                                                              amount: self.amount)
-
         buttonState = .loading()
-        selectedMint.getQuote(for: quoteRequest) { result in
-            switch result {
-            case .success(let (quote, event)):
-                self.quote = quote
-                pendingMintEvent = event
-                AppSchemaV1.insert([event], into: modelContext)
 
-                buttonState = .idle(String(localized: "Issue Ecash"), action: {
-                    requestMint()
-                })
-            case .failure(let error):
-                displayAlert(alert: AlertDetail(with: error))
-                logger.error("""
-                             could not get quote from mint \(selectedMint.url.absoluteString) \
-                             because of error \(error)
-                             """)
-                buttonState = .fail()
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                    buttonState = .idle(String(localized: "Get Invoice"), action: getQuote)
-                }
+        if selectedOption.method == .bolt11 {
+            let quoteRequest = CashuSwift.Bolt11.MintQuoteRequest(unit: selectedOption.unit.currencyCode.lowercased(),
+                                                                  amount: self.amount)
+            selectedMint.getQuote(for: quoteRequest) { result in
+                handleQuoteResult(result.map { (MintQuoteVariant.bolt11($0.quote), $0.event) },
+                                  from: selectedMint)
+            }
+        } else {
+            selectedMint.getGenericMintQuote(method: selectedOption.method,
+                                             unit: selectedOption.unitCode,
+                                             amount: self.amount) { result in
+                handleQuoteResult(result.map { (MintQuoteVariant.generic($0.quote), $0.event) },
+                                  from: selectedMint)
+            }
+        }
+    }
+
+    private func handleQuoteResult(_ result: Result<(MintQuoteVariant, Event), Error>, from mint: Mint) {
+        switch result {
+        case .success(let (quote, event)):
+            self.quote = quote
+            pendingMintEvent = event
+            AppSchemaV1.insert([event], into: modelContext)
+
+            buttonState = .idle(String(localized: "Issue Ecash"), action: {
+                requestMint()
+            })
+        case .failure(let error):
+            displayAlert(alert: AlertDetail(with: error))
+            logger.error("""
+                         could not get quote from mint \(mint.url.absoluteString) \
+                         because of error \(error)
+                         """)
+            buttonState = .fail()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                buttonState = .idle(getQuoteButtonLabel, action: getQuote)
             }
         }
     }
@@ -247,7 +275,7 @@ struct MintView: View {
             do {
                 buttonState = .loading()
                 if !hasLoggedPollingStart {
-                    print("auto polling for quote state with mint \(selectedMint.url.absoluteString) and id \(quote.quote)", terminator: "")
+                    print("auto polling for quote state with mint \(selectedMint.url.absoluteString) and id \(quote.quoteID)", terminator: "")
                     fflush(stdout)
                     hasLoggedPollingStart = true
                 } else {
@@ -255,9 +283,27 @@ struct MintView: View {
                     fflush(stdout)
                 }
                 isCheckingInvoiceState = true
-                let mintQuote = try await CashuSwift.Bolt11.mintQuoteState(quote.quote, from: CashuSwift.Mint(selectedMint))
 
-                if mintQuote.state == .paid {
+                let readyToIssue: Bool
+                switch quote {
+                case .bolt11(let bolt11Quote):
+                    let mintQuote = try await CashuSwift.Bolt11.mintQuoteState(bolt11Quote.quote, from: CashuSwift.Mint(selectedMint))
+                    readyToIssue = mintQuote.state == .paid
+                case .generic(let genericQuote):
+                    // Poll results are read for paidness only and never stored: they
+                    // lack the locking-key counter grafted onto the held quote.
+                    let fresh = try await CashuSwift.Generic.mintQuoteState(genericQuote.quote,
+                                                                            method: genericQuote.method,
+                                                                            from: CashuSwift.Mint(selectedMint))
+                    if fresh.indicatesIssued {
+                        pollingTimer?.invalidate()
+                        readyToIssue = false
+                    } else {
+                        readyToIssue = fresh.indicatesPaid
+                    }
+                }
+
+                if readyToIssue {
                     print("")  // New line after polling completes
                     isCheckingInvoiceState = false
                     await MainActor.run {
@@ -297,21 +343,61 @@ struct MintView: View {
 
         Task {
             do {
-                let issueResult = try await CashuSwift.Bolt11.mint(quote: quote,
-                                                                   from: CashuSwift.Mint(selectedMint),
+                let sendableMint = CashuSwift.Mint(selectedMint)
+                let issueResult: CashuSwift.IssueResult
+                let event: Event
+
+                switch quote {
+                case .bolt11(let bolt11Quote):
+                    issueResult = try await CashuSwift.Bolt11.mint(quote: bolt11Quote,
+                                                                   from: sendableMint,
                                                                    seed: activeWallet.seed,
                                                                    preferredDistribution: nil)
 
-                logger.info("DLEQ check on issuance \(String(describing: issueResult.dleqResult))")
+                    try selectedMint.addProofs(issueResult.proofs, to: modelContext)
 
-                try selectedMint.addProofs(issueResult.proofs, to: modelContext)
-
-                let event = Event.mintEvent(unit: Unit(code: quote.unit),
+                    event = Event.mintEvent(unit: Unit(code: bolt11Quote.unit),
                                             shortDescription: "Ecash created",
                                             wallet: activeWallet,
-                                            quote: quote,
+                                            quote: bolt11Quote,
                                             mint: selectedMint,
-                                            amount: quote.amount ?? issueResult.proofs.sum)
+                                            amount: bolt11Quote.amount ?? issueResult.proofs.sum)
+
+                case .generic(let genericQuote):
+                    let issueAmount = genericQuote.amount ?? (amount > 0 ? amount : nil)
+
+                    if genericQuote.lockingPubkey != nil {
+                        guard let counter = genericQuote.nut20Counter else {
+                            throw macadamiaError.databaseError("The pending quote is NUT-20 locked but its signing-key counter was not persisted.")
+                        }
+                        let key = try CashuSwift.Generic.quoteLockingKey(seed: activeWallet.seed, counter: counter)
+                        issueResult = try await CashuSwift.Generic.mint(quote: genericQuote,
+                                                                        from: sendableMint,
+                                                                        seed: activeWallet.seed,
+                                                                        quoteKey: key.privateKey,
+                                                                        amount: issueAmount,
+                                                                        signatureFormat: .legacyConcat) // cdk <= rev 6132607
+                    } else {
+                        guard let issueAmount else {
+                            throw CashuError.invalidAmount
+                        }
+                        issueResult = try await CashuSwift.Generic.mint(quote: genericQuote,
+                                                                        from: sendableMint,
+                                                                        amount: issueAmount,
+                                                                        seed: activeWallet.seed)
+                    }
+
+                    try selectedMint.addProofs(issueResult.proofs, to: modelContext)
+
+                    event = Event.mintEvent(unit: Unit(code: genericQuote.unit),
+                                            shortDescription: "Ecash created",
+                                            wallet: activeWallet,
+                                            genericQuote: genericQuote,
+                                            mint: selectedMint,
+                                            amount: genericQuote.amount ?? issueResult.proofs.sum)
+                }
+
+                logger.info("DLEQ check on issuance \(String(describing: issueResult.dleqResult))")
 
                 modelContext.insert(event)
                 try modelContext.save()

--- a/macadamia/Wallet/MintView.swift
+++ b/macadamia/Wallet/MintView.swift
@@ -89,6 +89,14 @@ struct MintView: View {
                             }
                             .foregroundStyle(.secondary)
                         }
+                        if case .generic = quote {
+                            // The mint operator matches a deposit by the trailing
+                            // characters of the quote id, so show them prominently.
+                            Text(String(quote.quoteID.suffix(6)))
+                                .font(.title3)
+                                .monospaced()
+                                .frame(maxWidth: .infinity, alignment: .center)
+                        }
                         QRView(string: quote.request)
                         Button {
                             copyToClipboard()

--- a/macadamia/Wallet/Pay/MeltView.swift
+++ b/macadamia/Wallet/Pay/MeltView.swift
@@ -416,3 +416,454 @@ struct MeltView: View {
         showAlert = true
     }
 }
+
+/// Self-contained withdrawal flow for non-BOLT11 NUT-05 melt methods (e.g. a
+/// custom "branch" method): amount + optional memo -> generic melt quote ->
+/// execute with prefer_async -> poll until the operator settles or fails the
+/// payout. Single mint, single unit, no MPP. BOLT11 payments stay in
+/// `MeltView` / `BOLT11MeltQuoteSource`.
+struct GenericMeltView: View {
+
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismissToRoot) private var dismissToRoot
+    @EnvironmentObject private var appState: AppState
+
+    @Query(filter: #Predicate<Wallet> { wallet in
+        wallet.active == true
+    }) private var wallets: [Wallet]
+
+    @State private var amount: Int = 0
+    @State private var memo: String = ""
+    @State private var selectedMint: Mint?
+    @State private var selectedOption: PaymentOption?
+    @State private var quote: CashuSwift.Generic.MeltQuote?
+    @State private var pendingMeltEvent: Event?
+    @State private var showDetails = false
+
+    @State private var buttonState = ActionButtonState.idle("...")
+    @State private var pollingTimer: Timer?
+    @State private var isCheckingState = false
+
+    @State private var showAlert = false
+    @State private var currentAlert: AlertDetail?
+
+    private var activeWallet: Wallet? {
+        wallets.first
+    }
+
+    init(pendingEvent: Event? = nil) {
+        _pendingMeltEvent = State(initialValue: pendingEvent)
+        if let pendingEvent, let quote = pendingEvent.genericMeltQuote {
+            _quote = State(initialValue: quote)
+            _amount = State(initialValue: quote.amount)
+            _memo = State(initialValue: pendingEvent.memo ?? "")
+            if let mint = pendingEvent.mints?.first {
+                _selectedMint = State(initialValue: mint)
+                _selectedOption = State(initialValue: PaymentOption(mintID: mint.mintID,
+                                                                    direction: .melt,
+                                                                    unit: Unit(code: quote.unit),
+                                                                    method: PaymentMethodKind(quote.method)))
+            }
+        }
+    }
+
+    var body: some View {
+        ZStack {
+            Form {
+                Section {
+                    NumericalInputView(output: $amount,
+                                       baseUnit: selectedOption?.unit ?? .sat,
+                                       exchangeRates: selectedOption?.unit.kind == .other ? nil : appState.exchangeRates,
+                                       onReturn: getQuote)
+                    MintPicker(label: String(localized: "Mint"), selectedMint: $selectedMint)
+                    PaymentOptionPicker(direction: .melt,
+                                        label: String(localized: "Method"),
+                                        selectedMint: $selectedMint,
+                                        selectedOption: $selectedOption,
+                                        excludedMethods: [.bolt11],
+                                        hidesWhenSingleOption: false)
+                    TextField(String(localized: "Memo (optional)"), text: $memo)
+                        .autocorrectionDisabled()
+                        .onChange(of: memo) { _, newValue in
+                            if newValue.count > 1024 { memo = String(newValue.prefix(1024)) }
+                        }
+                }
+                .disabled(quote != nil || pendingMeltEvent != nil)
+
+                if let quote {
+                    Section {
+                        HStack {
+                            Text("Amount: ")
+                            Spacer()
+                            AmountView(amount: quote.amount, unit: Unit(code: quote.unit))
+                                .monospaced()
+                        }
+                        if quote.feeReserve > 0 {
+                            HStack {
+                                Text("Fee:")
+                                Spacer()
+                                AmountView(amount: quote.feeReserve, unit: Unit(code: quote.unit))
+                                    .monospaced()
+                            }
+                            .foregroundStyle(.secondary)
+                        }
+                        if let expiry = quote.expiry {
+                            HStack {
+                                Text("Expires at: ")
+                                Spacer()
+                                Text(Date(timeIntervalSince1970: TimeInterval(expiry)).formatted())
+                            }
+                            .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    if pendingMeltEvent != nil {
+                        Section {
+                            HStack(spacing: 12) {
+                                ProgressView()
+                                Text("Waiting for the mint operator to confirm the payout. This can take a few minutes.")
+                                    .foregroundStyle(.secondary)
+                                    .font(.callout)
+                            }
+                        }
+                    }
+
+                    Section {
+                        Button {
+                            withAnimation {
+                                showDetails.toggle()
+                            }
+                        } label: {
+                            HStack {
+                                if showDetails {
+                                    Text("Hide details")
+                                } else {
+                                    Text("Show details")
+                                }
+                                Spacer()
+                                Image(systemName: "chevron.right")
+                                    .foregroundColor(.secondary)
+                                    .font(.footnote)
+                                    .rotationEffect(.degrees(showDetails ? 90 : 0))
+                            }
+                            .opacity(0.8)
+                        }
+
+                        if showDetails {
+                            CopyableRow(label: String(localized: "Quote ID"), value: quote.quote)
+                        }
+                    }
+                }
+
+                Spacer(minLength: 50)
+                    .listRowBackground(Color.clear)
+            }
+            VStack {
+                Spacer()
+                ActionButton(state: $buttonState)
+                    .actionDisabled(actionButtonDisabled)
+            }
+        }
+        .navigationTitle("Withdrawal")
+        .alertView(isPresented: $showAlert, currentAlert: currentAlert)
+        .onAppear {
+            updateButtonState()
+            if pendingMeltEvent != nil {
+                startPolling()
+            }
+        }
+        .onDisappear {
+            pollingTimer?.invalidate()
+        }
+    }
+
+    // MARK: - Button orchestration
+
+    private var actionButtonDisabled: Bool {
+        if pendingMeltEvent != nil || quote != nil { return false }
+        guard amount > 0, let selectedMint, let selectedOption else { return true }
+        if let minAmount = selectedOption.minAmount, amount < minAmount { return true }
+        if let maxAmount = selectedOption.maxAmount, amount > maxAmount { return true }
+        return selectedMint.balance(for: selectedOption.unit) < amount
+    }
+
+    private func updateButtonState() {
+        if pendingMeltEvent != nil {
+            buttonState = .idle(String(localized: "Check Payment State"), action: { checkState(manual: true) })
+        } else if quote != nil {
+            buttonState = .idle(String(localized: "Withdraw"), action: { executeMelt() })
+        } else {
+            buttonState = .idle(String(localized: "Get Quote"), action: { getQuote() })
+        }
+    }
+
+    // MARK: - Quote
+
+    private func getQuote() {
+        guard let selectedMint, let selectedOption, amount > 0, quote == nil else { return }
+
+        buttonState = .loading()
+
+        let sendableMint = CashuSwift.Mint(selectedMint)
+        let methodID = selectedOption.method.id
+        // cdk requires `method` repeated inside the body and the payout declared
+        // as a flattened `amount` field; harmless for mints that ignore extras.
+        let quoteRequest = CashuSwift.Generic.MeltQuoteRequest(
+            method: methodID,
+            unit: selectedOption.unitCode,
+            request: memo,
+            extra: ["method": .string(methodID.rawValue),
+                    "amount": .integer(Int64(amount))]
+        )
+        let requestedAmount = amount
+
+        Task {
+            do {
+                let freshQuote = try await CashuSwift.Generic.requestMeltQuote(quoteRequest, from: sendableMint)
+                await MainActor.run {
+                    guard freshQuote.amount == requestedAmount else {
+                        displayAlert(alert: AlertDetail(title: String(localized: "Amount Mismatch"),
+                                                        description: String(localized: "The mint's quote amount does not match the requested amount.")))
+                        updateButtonState()
+                        return
+                    }
+                    self.quote = freshQuote
+                    updateButtonState()
+                }
+            } catch {
+                await MainActor.run {
+                    displayAlert(alert: AlertDetail(with: error))
+                    buttonState = .fail()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                        updateButtonState()
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Execution
+
+    private func executeMelt() {
+        guard let quote, let selectedMint, let selectedOption, let activeWallet,
+              pendingMeltEvent == nil else { return }
+
+        guard let selection = selectedMint.select(amount: quote.amount + quote.feeReserve,
+                                                  unit: selectedOption.unit) else {
+            displayAlert(alert: AlertDetail(title: String(localized: "Proof Selection Error"),
+                                            description: String(localized: "The wallet was not able to pick ecash proofs from mint \(selectedMint.displayName).")))
+            return
+        }
+
+        buttonState = .loading()
+
+        let event = Event.pendingMeltEvent(unit: selectedOption.unit,
+                                           shortDescription: String(localized: "Pending Withdrawal"),
+                                           wallet: activeWallet,
+                                           genericQuote: quote,
+                                           amount: quote.amount,
+                                           expiration: quote.expiry.map { Date(timeIntervalSince1970: TimeInterval($0)) },
+                                           mints: [selectedMint],
+                                           proofs: selection.selected,
+                                           memo: memo.isEmpty ? nil : memo)
+
+        do {
+            let blankOutputs = try CashuSwift.generateBlankOutputs(quote: quote,
+                                                                   proofs: selection.selected,
+                                                                   mint: selectedMint,
+                                                                   unit: quote.unit,
+                                                                   seed: activeWallet.seed)
+            // An empty set is legitimate (no overpayment beyond the fee reserve).
+            if !blankOutputs.outputs.isEmpty, let keysetID = blankOutputs.outputs.first?.id {
+                selectedMint.increaseDerivationCounterForKeysetWithID(keysetID, by: blankOutputs.outputs.count)
+                event.blankOutputs = BlankOutputSet(tuple: blankOutputs)
+            }
+        } catch {
+            logger.error("failed to create blank outputs for generic melt on mint \(selectedMint.url) due to error \(error)")
+        }
+
+        modelContext.insert(event)
+        try? modelContext.save()
+        selection.selected.setState(.pending)
+        pendingMeltEvent = event
+
+        runMelt(event: event)
+    }
+
+    private func runMelt(event: Event) {
+        guard let selectedMint, let quote = event.genericMeltQuote else { return }
+
+        buttonState = .loading()
+
+        let sendableMint = CashuSwift.Mint(selectedMint)
+        let sendableProofs = event.proofs?.sendable() ?? []
+        let blankOutputs = event.blankOutputs.flatMap { $0.outputs.isEmpty ? nil : $0.tuple() }
+
+        Task {
+            do {
+                let result = try await CashuSwift.Generic.melt(quote: quote,
+                                                               from: sendableMint,
+                                                               proofs: sendableProofs,
+                                                               blankOutputs: blankOutputs,
+                                                               preferAsync: true)
+                await MainActor.run {
+                    if result.quote.state == .paid {
+                        finalize(result: result)
+                    } else if result.quote.isFailed {
+                        fail()
+                    } else {
+                        startPolling()
+                    }
+                }
+            } catch CashuError.quoteIsPending {
+                // Error code 20005: the operator has not settled the payout inside
+                // the mint's synchronous window — not a failure, keep polling.
+                await MainActor.run { startPolling() }
+            } catch {
+                await MainActor.run {
+                    displayAlert(alert: AlertDetail(with: error))
+                    updateButtonState()
+                }
+            }
+        }
+    }
+
+    // MARK: - Polling
+
+    private func startPolling() {
+        updateButtonState()
+        guard pollingTimer?.isValid != true else { return }
+        pollingTimer = Timer.scheduledTimer(withTimeInterval: 5, repeats: true, block: { _ in
+            Task { @MainActor in
+                checkState()
+            }
+        })
+    }
+
+    private func checkState(manual: Bool = false) {
+        guard let pendingMeltEvent, let quote = pendingMeltEvent.genericMeltQuote,
+              let mint = pendingMeltEvent.mints?.first else { return }
+        if isCheckingState { return }
+        isCheckingState = true
+
+        let sendableMint = CashuSwift.Mint(mint)
+        let blankOutputs = pendingMeltEvent.blankOutputs.flatMap { $0.outputs.isEmpty ? nil : $0.tuple() }
+
+        Task {
+            do {
+                let result = try await CashuSwift.Generic.meltState(quote.quote,
+                                                                    method: quote.method,
+                                                                    from: sendableMint,
+                                                                    blankOutputs: blankOutputs)
+                await MainActor.run {
+                    isCheckingState = false
+                    switch result.quote.state {
+                    case .paid:
+                        finalize(result: result)
+                    case .unpaid:
+                        pollingTimer?.invalidate()
+                        let primary = AlertButton(title: String(localized: "Retry"),
+                                                  action: { runMelt(event: pendingMeltEvent) })
+                        let secondary = AlertButton(title: String(localized: "Remove Payment"),
+                                                    role: .destructive,
+                                                    action: { removePending() })
+                        displayAlert(alert: AlertDetail(title: String(localized: "Unpaid ⚠"),
+                                                        description: String(localized: "This payment did not go through and is marked \"unpaid\" with the mint. Would you like to try again?"),
+                                                        primaryButton: primary,
+                                                        secondaryButton: secondary))
+                        updateButtonState()
+                    case .pending:
+                        if manual {
+                            displayAlert(alert: AlertDetail(title: String(localized: "Payment Pending ⏳"),
+                                                            description: String(localized: "Waiting for the mint operator to confirm the payout. This can take a few minutes.")))
+                            updateButtonState()
+                        }
+                    default:
+                        // FAILED and UNKNOWN decode to a nil typed state; the raw
+                        // string distinguishes them.
+                        if result.quote.isFailed {
+                            fail()
+                        } else if manual {
+                            displayAlert(alert: AlertDetail(title: String(localized: "Withdrawal"),
+                                                            description: String(localized: "The state of this withdrawal could not be determined. Please check again later.")))
+                            updateButtonState()
+                        }
+                    }
+                }
+            } catch CashuError.quoteIsPending {
+                await MainActor.run { isCheckingState = false }
+            } catch {
+                await MainActor.run {
+                    isCheckingState = false
+                    pollingTimer?.invalidate()
+                    displayAlert(alert: AlertDetail(with: error))
+                    updateButtonState()
+                }
+            }
+        }
+    }
+
+    // MARK: - Settlement
+
+    private func finalize(result: CashuSwift.MeltResult<CashuSwift.Generic.MeltQuote>) {
+        guard let activeWallet, let pendingMeltEvent,
+              let storedQuote = pendingMeltEvent.genericMeltQuote,
+              let mint = pendingMeltEvent.mints?.first else { return }
+
+        pollingTimer?.invalidate()
+
+        pendingMeltEvent.proofs?.setState(.spent)
+        pendingMeltEvent.visible = false
+
+        let internalChange = try? mint.addProofs(result.change ?? [], to: modelContext)
+
+        // Melt results come off the wire without a method — re-graft the stored
+        // quote's method so the persisted event routes to the generic accessor.
+        let finalQuote = result.quote.settingMethod(storedQuote.method)
+
+        let event = Event.meltEvent(unit: pendingMeltEvent.currencyUnit,
+                                    shortDescription: String(localized: "Withdrawal"),
+                                    wallet: activeWallet,
+                                    amount: result.quote.amount,
+                                    longDescription: "",
+                                    mints: [mint],
+                                    change: internalChange,
+                                    preImage: result.quote.paymentPreimage,
+                                    memo: pendingMeltEvent.memo,
+                                    genericQuote: finalQuote)
+        modelContext.insert(event)
+        try? modelContext.save()
+
+        buttonState = .success(String(localized: "Paid!"))
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            dismissToRoot()
+        }
+    }
+
+    private func fail() {
+        pollingTimer?.invalidate()
+        // A FAILED quote means the mint has released the locked inputs.
+        pendingMeltEvent?.proofs?.setState(.valid)
+        pendingMeltEvent?.visible = false
+        try? modelContext.save()
+        pendingMeltEvent = nil
+        quote = nil
+        displayAlert(alert: AlertDetail(title: String(localized: "Withdrawal Failed"),
+                                        description: String(localized: "The mint reported this withdrawal as failed. Your ecash has been returned to your balance.")))
+        updateButtonState()
+    }
+
+    private func removePending() {
+        pollingTimer?.invalidate()
+        pendingMeltEvent?.proofs?.setState(.valid)
+        pendingMeltEvent?.visible = false
+        try? modelContext.save()
+        dismissToRoot()
+    }
+
+    private func displayAlert(alert: AlertDetail) {
+        currentAlert = alert
+        showAlert = true
+    }
+}

--- a/macadamia/Wallet/Pay/PayeeInputView.swift
+++ b/macadamia/Wallet/Pay/PayeeInputView.swift
@@ -76,7 +76,27 @@ struct PayeeInputView: View {
             }
             .opacity(hideScanner ? 0 : 1)
             .animation(.easeInOut(duration: 0.2), value: hideScanner)
-            
+
+            Spacer().frame(height: 20)
+
+            NavigationLink {
+                GenericMeltView()
+            } label: {
+                HStack {
+                    Image(systemName: "banknote")
+                    Text("Other Withdrawal Methods")
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+                .padding()
+                .background(RoundedRectangle(cornerRadius: 12).fill(Color.gray.opacity(0.3)))
+            }
+            .foregroundStyle(.primary)
+            .opacity(hideScanner ? 0 : 1)
+            .animation(.easeInOut(duration: 0.2), value: hideScanner)
+
             Spacer()
         }
         .padding()

--- a/macadamiaTests/macadamiaTests.swift
+++ b/macadamiaTests/macadamiaTests.swift
@@ -1307,3 +1307,235 @@ private enum LegacyMeltSchema {
         }
     }
 }
+
+final class GenericQuoteTests: XCTestCase {
+
+    var container: ModelContainer!
+
+    override func setUp() {
+        super.setUp()
+        let schema = Schema([Proof.self, Mint.self, Wallet.self])
+        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+        do {
+            container = try ModelContainer(for: schema, configurations: [configuration])
+        } catch {
+            XCTFail("Failed to create in-memory container: \(error)")
+        }
+    }
+
+    override func tearDown() {
+        container = nil
+        super.tearDown()
+    }
+
+    private func makeGenericMintQuote(counter: UInt32? = nil) -> CashuSwift.Generic.MintQuote {
+        var quote = CashuSwift.Generic.MintQuote(
+            method: CashuSwift.PaymentMethodID(rawValue: "branch"),
+            quote: "0197f3a1-4c2b-7c10-9d3e-8a1b2c3d4e5f",
+            request: "MINT-0197f3a1-4c2b-7c10-9d3e-8a1b2c3d4e5f",
+            unit: "ora",
+            amount: 250,
+            state: nil,
+            expiry: 1785283200,
+            raw: ["quote": .string("0197f3a1-4c2b-7c10-9d3e-8a1b2c3d4e5f"),
+                  "request": .string("MINT-0197f3a1-4c2b-7c10-9d3e-8a1b2c3d4e5f"),
+                  "unit": .string("ora"),
+                  "amount": .integer(250),
+                  "amount_paid": .integer(0),
+                  "amount_issued": .integer(0),
+                  "expiry": .integer(1785283200),
+                  "method": .string("branch"),
+                  "pubkey": .string("02aabbccdd")]
+        )
+        if let counter {
+            quote = quote.addingNut20Counter(counter)
+        }
+        return quote
+    }
+
+    private func makeGenericMeltQuote(rawState: String? = "UNPAID") -> CashuSwift.Generic.MeltQuote {
+        var raw: CashuSwift.JSONObject = ["quote": .string("0197f3b2-melt"),
+                                          "amount": .integer(500),
+                                          "unit": .string("ora"),
+                                          "fee_reserve": .integer(0),
+                                          "expiry": .integer(1785282300),
+                                          "method": .string("branch")]
+        if let rawState {
+            raw["state"] = .string(rawState)
+        }
+        return CashuSwift.Generic.MeltQuote(
+            method: CashuSwift.PaymentMethodID(rawValue: "branch"),
+            quote: "0197f3b2-melt",
+            amount: 500,
+            unit: "ora",
+            feeReserve: 0,
+            state: rawState.flatMap { CashuSwift.QuoteState(rawValue: $0) },
+            expiry: 1785282300,
+            paymentPreimage: nil,
+            change: nil,
+            raw: raw
+        )
+    }
+
+    @MainActor
+    func testGenericMintQuoteAccessorRouting() throws {
+        let context = container.mainContext
+        let mnemonic = Mnemonic()
+        let wallet = Wallet(mnemonic: mnemonic.phrase.joined(separator: " "), seed: String(bytes: mnemonic.seed))
+        context.insert(wallet)
+
+        let event = Event(date: Date(),
+                          unit: Unit(code: "ora"),
+                          shortDescription: "test",
+                          visible: true,
+                          kind: .pendingMint,
+                          wallet: wallet)
+        event.genericMintQuote = makeGenericMintQuote(counter: 1234567)
+        context.insert(event)
+        try context.save()
+
+        // A generic row must never surface through the BOLT11-typed accessor …
+        XCTAssertNil(event.mintQuote)
+        // … and must round-trip through the generic one with method and counter intact.
+        let restored = try XCTUnwrap(event.genericMintQuote)
+        XCTAssertEqual(restored.method.rawValue, "branch")
+        XCTAssertEqual(restored.quote, "0197f3a1-4c2b-7c10-9d3e-8a1b2c3d4e5f")
+        XCTAssertEqual(restored.request, "MINT-0197f3a1-4c2b-7c10-9d3e-8a1b2c3d4e5f")
+        XCTAssertEqual(restored.unit, "ora")
+        XCTAssertEqual(restored.amount, 250)
+        XCTAssertEqual(restored.nut20Counter, 1234567)
+        XCTAssertEqual(restored.lockingPubkey, "02aabbccdd")
+    }
+
+    @MainActor
+    func testBolt11MintQuoteAccessorUnaffected() throws {
+        let context = container.mainContext
+        let mnemonic = Mnemonic()
+        let wallet = Wallet(mnemonic: mnemonic.phrase.joined(separator: " "), seed: String(bytes: mnemonic.seed))
+        context.insert(wallet)
+
+        let bolt11Quote = CashuSwift.Bolt11.MintQuote(quote: "b11-quote",
+                                                      request: "lnbc10n1...",
+                                                      amount: 21,
+                                                      unit: "sat",
+                                                      state: .unpaid,
+                                                      expiry: 1785283200)
+        let event = Event(date: Date(),
+                          unit: .sat,
+                          shortDescription: "test",
+                          visible: true,
+                          kind: .pendingMint,
+                          wallet: wallet,
+                          mintQuote: bolt11Quote)
+        context.insert(event)
+        try context.save()
+
+        XCTAssertEqual(event.mintQuote?.quote, "b11-quote")
+        XCTAssertNil(event.genericMintQuote)
+    }
+
+    @MainActor
+    func testGenericMeltQuoteAccessorRouting() throws {
+        let context = container.mainContext
+        let mnemonic = Mnemonic()
+        let wallet = Wallet(mnemonic: mnemonic.phrase.joined(separator: " "), seed: String(bytes: mnemonic.seed))
+        context.insert(wallet)
+
+        let event = Event(date: Date(),
+                          unit: Unit(code: "ora"),
+                          shortDescription: "test",
+                          visible: true,
+                          kind: .pendingMelt,
+                          wallet: wallet)
+        event.genericMeltQuote = makeGenericMeltQuote()
+        context.insert(event)
+        try context.save()
+
+        XCTAssertNil(event.bolt11MeltQuote)
+        let restored = try XCTUnwrap(event.genericMeltQuote)
+        XCTAssertEqual(restored.method.rawValue, "branch")
+        XCTAssertEqual(restored.amount, 500)
+        XCTAssertEqual(restored.unit, "ora")
+
+        let bolt11Melt = CashuSwift.Bolt11.MeltQuote(quote: "b11-melt",
+                                                     request: "lnbc10n1...",
+                                                     amount: 21,
+                                                     unit: "sat",
+                                                     feeReserve: 1,
+                                                     state: .unpaid,
+                                                     expiry: nil)
+        let bolt11Event = Event(date: Date(),
+                                unit: .sat,
+                                shortDescription: "test",
+                                visible: true,
+                                kind: .pendingMelt,
+                                wallet: wallet,
+                                bolt11MeltQuote: bolt11Melt)
+        context.insert(bolt11Event)
+        try context.save()
+
+        XCTAssertEqual(bolt11Event.bolt11MeltQuote?.quote, "b11-melt")
+        XCTAssertNil(bolt11Event.genericMeltQuote)
+    }
+
+    func testIndicatesPaidAndIssued() {
+        // Nothing paid yet.
+        XCTAssertFalse(makeGenericMintQuote().indicatesPaid)
+
+        // amount_paid covers the quote amount (the "branch" signal — no state field).
+        var quote = makeGenericMintQuote()
+        var raw = quote.raw
+        raw["amount_paid"] = .integer(250)
+        quote = CashuSwift.Generic.MintQuote(method: quote.method, quote: quote.quote, request: quote.request,
+                                             unit: quote.unit, amount: quote.amount, state: quote.state,
+                                             expiry: quote.expiry, raw: raw)
+        XCTAssertTrue(quote.indicatesPaid)
+        XCTAssertFalse(quote.indicatesIssued)
+
+        // Fully issued.
+        raw["amount_issued"] = .integer(250)
+        quote = CashuSwift.Generic.MintQuote(method: quote.method, quote: quote.quote, request: quote.request,
+                                             unit: quote.unit, amount: quote.amount, state: quote.state,
+                                             expiry: quote.expiry, raw: raw)
+        XCTAssertTrue(quote.indicatesIssued)
+
+        // Typed and raw state signals.
+        raw = makeGenericMintQuote().raw
+        raw["state"] = .string("PAID")
+        let statePaid = CashuSwift.Generic.MintQuote(method: "branch", quote: "q", request: "r", unit: "ora",
+                                                     amount: 250, state: nil, expiry: nil, raw: raw)
+        XCTAssertTrue(statePaid.indicatesPaid)
+        raw["state"] = .string("ISSUED")
+        let stateIssued = CashuSwift.Generic.MintQuote(method: "branch", quote: "q", request: "r", unit: "ora",
+                                                       amount: 250, state: nil, expiry: nil, raw: raw)
+        XCTAssertTrue(stateIssued.indicatesIssued)
+    }
+
+    func testMeltQuoteRawStateAndMethodGrafting() throws {
+        // FAILED decodes to a nil typed state but must stay readable.
+        let failed = makeGenericMeltQuote(rawState: "FAILED")
+        XCTAssertNil(failed.state)
+        XCTAssertEqual(failed.rawStateString, "FAILED")
+        XCTAssertTrue(failed.isFailed)
+        XCTAssertFalse(makeGenericMeltQuote(rawState: "UNPAID").isFailed)
+
+        // A melt/meltState result carries no method — settingMethod re-grafts it
+        // so the persisted JSON routes to the generic accessor after a round trip.
+        let wireQuote = CashuSwift.Generic.MeltQuote(
+            method: CashuSwift.PaymentMethodID(rawValue: ""),
+            quote: "0197f3b2-melt", amount: 500, unit: "ora", feeReserve: 0,
+            state: .paid, expiry: nil, paymentPreimage: "operator note", change: nil,
+            raw: ["quote": .string("0197f3b2-melt"),
+                  "amount": .integer(500),
+                  "unit": .string("ora"),
+                  "state": .string("PAID"),
+                  "payment_preimage": .string("operator note")]
+        )
+        let grafted = wireQuote.settingMethod(CashuSwift.PaymentMethodID(rawValue: "branch"))
+        let data = try JSONEncoder().encode(grafted)
+        let decoded = try JSONDecoder().decode(CashuSwift.Generic.MeltQuote.self, from: data)
+        XCTAssertEqual(decoded.method.rawValue, "branch")
+        XCTAssertEqual(decoded.paymentPreimage, "operator note")
+        XCTAssertEqual(decoded.state, .paid)
+    }
+}


### PR DESCRIPTION
## Summary

Removes the hard bolt11-only gate so every payment method a mint advertises in NUT-04/NUT-05 is usable — specifically the custom `branch` method (custom units, teller-settled) — via CashuSwift's `Generic` quote API.

- **Mint:** the payment-option picker no longer filters to bolt11. Unknown methods request a quote through `CashuSwift.Generic`, locked to a fresh NUT-20 key (`m/129373'/20'/0'/0'/{counter}`); the derivation counter is grafted into the quote's raw JSON so issuance can re-sign after an app restart (`legacyConcat` format for cdk mints). Paid detection falls back to `amount_paid`/`amount_issued` for state-less methods, and the last six quote-id characters are shown above the QR for teller matching.
- **Melt:** new self-contained `GenericMeltView` (amount + memo instead of an invoice) behind an "Other Withdrawal Methods" entry on the Pay screen. Executes with `prefer_async: true`, polls until `PAID`/`FAILED`, restores locked proofs on failure. `struct MeltView` itself is untouched.
- **Persistence:** generic quotes reuse the existing `bolt11MintQuoteData`/`bolt11MeltQuoteData` columns; a method-key probe routes rows between typed accessors — no SwiftData schema change, bolt11/transfer/MPP rows provably unaffected.
- **Dependency:** cashu-swift pinned 0.4.1 → 0.4.3 (NUT-20 hoisted into the `Generic` namespace; the discarded quote-offer mechanism is not shipped).
- 14 new strings localized in all 12 languages.

## Test plan

- [x] `GenericQuoteTests` (new): accessor routing in both directions, bolt11 rows unaffected, NUT-20 counter round-trip, paid/issued detection matrix, melt raw-state + method grafting
- [x] `TransferFlowTests` (existing 13): all pass unchanged
- [x] App builds for iOS Simulator
- [ ] Manual against the branch mint: deposit (quote → teller confirms → auto-issue, incl. kill-and-resume) and withdrawal (quote → prefer_async melt → teller confirms `PAID` / voids `FAILED` with proofs restored)
- [ ] Regression at a public mint: bolt11 deposit and pay flows unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)